### PR TITLE
Fix cdedup build on Python 3.12+

### DIFF
--- a/.github/actions/setup-boar/action.yml
+++ b/.github/actions/setup-boar/action.yml
@@ -39,7 +39,9 @@ runs:
         python -m venv .venv
         source .venv/bin/activate
         python -V
-        pip install -U pip pytest cython
+        pip install -U pip
+        pip install -r requirements.txt
+        pip install cython
 
     - name: Set up virtualenv (no cython)
       if: ${{ inputs.build-dedup != 'true' }}
@@ -48,7 +50,8 @@ runs:
         python -m venv .venv
         source .venv/bin/activate
         python -V
-        pip install -U pip pytest
+        pip install -U pip
+        pip install -r requirements.txt
 
     - name: Build dedup extension (cdedup.so)
       if: ${{ inputs.build-dedup == 'true' }}

--- a/boar
+++ b/boar
@@ -427,7 +427,7 @@ def _parse_range(s, default_lower, default_upper):
         return int(s), int(s)
     except ValueError:
         pass
-    m = re.match("^(\d*):(\d*)$", s)
+    m = re.match(r"^(\d*):(\d*)$", s)
     if not m:
         raise UserError("Ranges must be given as N:M where N and M may be an empty string or an integer")
     lower = int(m.group(1)) if m.group(1) else default_lower

--- a/boar_common.py
+++ b/boar_common.py
@@ -119,7 +119,7 @@ def sorted_bloblist(bloblist):
 def parse_manifest_name(path):
     """Returns a tuple (lowercase hash name, hash). Both are None if
     the path is not a valid manifest filename."""
-    m = re.match("(^|.*/)(manifest-([a-z0-9]+).txt|manifest-([a-z0-9]{32})\.md5|(manifest.md5))", path, flags=re.IGNORECASE)
+    m = re.match(r"(^|.*/)(manifest-([a-z0-9]+)\.txt|manifest-([a-z0-9]{32})\.md5|(manifest\.md5))", path, flags=re.IGNORECASE)
     if not m:
         return None, None
     if m.group(5):

--- a/cdedup/setup-cython.py
+++ b/cdedup/setup-cython.py
@@ -1,40 +1,4 @@
-import importlib
-import importlib.util
-import subprocess
-import sys
-
-
-def _load_setuptools_components():
-    if importlib.util.find_spec("setuptools") is None:
-        ensurepip_spec = importlib.util.find_spec("ensurepip")
-        if ensurepip_spec is not None:
-            ensurepip = importlib.import_module("ensurepip")
-            try:
-                ensurepip.bootstrap()
-            except Exception:
-                pass
-        try:
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--upgrade",
-                    "pip",
-                    "setuptools",
-                    "wheel",
-                ]
-            )
-        except Exception as exc:  # pragma: no cover - fatal during packaging
-            raise ModuleNotFoundError(
-                "setuptools is required but could not be installed automatically"
-            ) from exc
-    setuptools = importlib.import_module("setuptools")
-    return setuptools.Extension, setuptools.setup
-
-
-Extension, setup = _load_setuptools_components()
+from setuptools import Extension, setup
 
 try:
     from Cython.Build import cythonize

--- a/cdedup/setup-cython.py
+++ b/cdedup/setup-cython.py
@@ -1,4 +1,11 @@
-from setuptools import Extension, setup
+try:
+    from setuptools import Extension, setup
+except ImportError:  # pragma: no cover - allow building without setuptools on legacy Python
+    try:
+        from distutils.core import setup  # type: ignore[attr-defined]
+        from distutils.extension import Extension  # type: ignore[attr-defined]
+    except ImportError as exc:  # Python 3.12+ without setuptools present
+        raise SystemExit("setuptools is required to build the cdedup extension") from exc
 
 try:
     from Cython.Build import cythonize

--- a/cdedup/setup-cython.py
+++ b/cdedup/setup-cython.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import Extension, setup
 
 try:
     from Cython.Build import cythonize

--- a/cdedup/setup-cython.py
+++ b/cdedup/setup-cython.py
@@ -1,13 +1,40 @@
-try:
-    from setuptools import Extension, setup
-except ModuleNotFoundError:
-    import ensurepip
-    import importlib
+import importlib
+import importlib.util
+import subprocess
+import sys
 
-    ensurepip.bootstrap()
+
+def _load_setuptools_components():
+    if importlib.util.find_spec("setuptools") is None:
+        ensurepip_spec = importlib.util.find_spec("ensurepip")
+        if ensurepip_spec is not None:
+            ensurepip = importlib.import_module("ensurepip")
+            try:
+                ensurepip.bootstrap()
+            except Exception:
+                pass
+        try:
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    "pip",
+                    "setuptools",
+                    "wheel",
+                ]
+            )
+        except Exception as exc:  # pragma: no cover - fatal during packaging
+            raise ModuleNotFoundError(
+                "setuptools is required but could not be installed automatically"
+            ) from exc
     setuptools = importlib.import_module("setuptools")
-    Extension = setuptools.Extension
-    setup = setuptools.setup
+    return setuptools.Extension, setuptools.setup
+
+
+Extension, setup = _load_setuptools_components()
 
 try:
     from Cython.Build import cythonize

--- a/cdedup/setup-cython.py
+++ b/cdedup/setup-cython.py
@@ -1,4 +1,13 @@
-from setuptools import Extension, setup
+try:
+    from setuptools import Extension, setup
+except ModuleNotFoundError:
+    import ensurepip
+    import importlib
+
+    ensurepip.bootstrap()
+    setuptools = importlib.import_module("setuptools")
+    Extension = setuptools.Extension
+    setup = setuptools.setup
 
 try:
     from Cython.Build import cythonize

--- a/client.py
+++ b/client.py
@@ -29,7 +29,7 @@ from blobrepo import repository
 from common import *
 from boar_exceptions import *
 
-BOAR_URL_PATTERN = "boar(\+(local|ssh|tcp))?://.+"
+BOAR_URL_PATTERN = r"boar(\+(local|ssh|tcp))?://.+"
 
 def is_boar_url(string):
     return re.match(BOAR_URL_PATTERN, string) != None
@@ -128,8 +128,8 @@ def _connect_cmd(cmd):
     return server.front
 
 def connect_ssh(url):
-    url_with_user_match = re.match("boar\+ssh://(.*)@([^/]+)(/.*)", url)
-    url_without_user_match = re.match("boar\+ssh://([^@/]+)(/.*)", url)
+    url_with_user_match = re.match(r"boar\+ssh://(.*)@([^/]+)(/.*)", url)
+    url_without_user_match = re.match(r"boar\+ssh://([^@/]+)(/.*)", url)
     if url_with_user_match:
         user, host, path = url_with_user_match.groups()
     elif url_without_user_match:
@@ -165,7 +165,7 @@ def connect_ssh(url):
     return _connect_cmd(cmd)
 
 def connect_tcp(url):
-    url_match = re.match("boar(\+tcp)?://(.*):(\d+)/?", url)
+    url_match = re.match(r"boar(\+tcp)?://(.*):(\d+)/?", url)
     assert url_match, "Not a valid Boar URL:" + url
     _, host, port = url_match.groups()
     port = int(port)
@@ -175,7 +175,7 @@ def connect_tcp(url):
         raise UserError("Network error: %s" % e)
 
 def connect_local(url):
-    url_match = re.match("boar\+local://(.*)/?", url)
+    url_match = re.match(r"boar\+local://(.*)/?", url)
     assert url_match, "Not a valid local Boar URL:" + url
     repopath, = url_match.groups()
     boarhome = os.path.dirname(os.path.abspath(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools>=65
+pytest

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,39 @@
-try:
-    from setuptools import setup
-except ModuleNotFoundError:
-    import ensurepip
-    import importlib
+import importlib
+import importlib.util
+import subprocess
+import sys
 
-    ensurepip.bootstrap()
-    setup = importlib.import_module("setuptools").setup
+
+def _load_setuptools():
+    if importlib.util.find_spec("setuptools") is None:
+        ensurepip_spec = importlib.util.find_spec("ensurepip")
+        if ensurepip_spec is not None:
+            ensurepip = importlib.import_module("ensurepip")
+            try:
+                ensurepip.bootstrap()
+            except Exception:
+                pass
+        try:
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--upgrade",
+                    "pip",
+                    "setuptools",
+                    "wheel",
+                ]
+            )
+        except Exception as exc:  # pragma: no cover - fatal during packaging
+            raise ModuleNotFoundError(
+                "setuptools is required but could not be installed automatically"
+            ) from exc
+    return importlib.import_module("setuptools")
+
+
+setup = _load_setuptools().setup
 
 import py2exe
 

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,4 @@
-import importlib
-import importlib.util
-import subprocess
-import sys
-
-
-def _load_setuptools():
-    if importlib.util.find_spec("setuptools") is None:
-        ensurepip_spec = importlib.util.find_spec("ensurepip")
-        if ensurepip_spec is not None:
-            ensurepip = importlib.import_module("ensurepip")
-            try:
-                ensurepip.bootstrap()
-            except Exception:
-                pass
-        try:
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--upgrade",
-                    "pip",
-                    "setuptools",
-                    "wheel",
-                ]
-            )
-        except Exception as exc:  # pragma: no cover - fatal during packaging
-            raise ModuleNotFoundError(
-                "setuptools is required but could not be installed automatically"
-            ) from exc
-    return importlib.import_module("setuptools")
-
-
-setup = _load_setuptools().setup
-
+from setuptools import setup
 import py2exe
 
 setup(console=['boar'])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import py2exe
 
 setup(console=['boar'])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
-from setuptools import setup
+try:
+    from setuptools import setup
+except ModuleNotFoundError:
+    import ensurepip
+    import importlib
+
+    ensurepip.bootstrap()
+    setup = importlib.import_module("setuptools").setup
+
 import py2exe
 
 setup(console=['boar'])

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:  # pragma: no cover - fallback for legacy Python installs
+    try:
+        from distutils.core import setup  # type: ignore[attr-defined]
+    except ImportError as exc:  # Python 3.12+ without setuptools present
+        raise SystemExit("setuptools is required to build Boar") from exc
+
 import py2exe
 
 setup(console=['boar'])

--- a/workdir.py
+++ b/workdir.py
@@ -117,7 +117,7 @@ class Workdir(object):
         if self.__get_workdir_version() == 2:
             files = os.listdir(self.metadir)
             for fn in files:
-                if re.match("^bloblistcache\d+\.bin$", fn):
+                if re.match(r"^bloblistcache\d+\.bin$", fn):
                     safe_delete_file(os.path.join(self.metadir, fn))
             self.__set_workdir_version(3)
 


### PR DESCRIPTION
## Summary
- replace distutils usage in setup scripts with setuptools so Python 3.12+ environments can import them

## Testing
- python -m compileall setup.py cdedup/setup-cython.py

------
https://chatgpt.com/codex/tasks/task_e_68ed6d7be04c832ab438afd7ba742d3c