### PR TITLE
Speed up CI by caching cdedup build artifacts

### DIFF
--- a/.github/actions/setup-boar/action.yml
+++ b/.github/actions/setup-boar/action.yml
@@ -32,6 +32,22 @@ runs:
         sudo apt-get update
         sudo apt-get install -y build-essential wget unzip
 
+    - name: Cache cdedup build artifacts
+      if: ${{ inputs.build-dedup == 'true' }}
+      id: cdedup-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          cdedup/sqlite3.c
+          cdedup/sqlite3.h
+          cdedup/sqlite3.o
+          cdedup/cdedup*.so
+          cdedup/build
+          cdedup.so
+        key: ${{ runner.os }}-cdedup-${{ inputs.python-version }}-${{ hashFiles('cdedup/Makefile', 'cdedup/setup-cython.py', 'cdedup/*.c', 'cdedup/*.h', 'cdedup/*.pyx') }}
+        restore-keys: |
+          ${{ runner.os }}-cdedup-${{ inputs.python-version }}-
+
     - name: Set up virtualenv (with cython)
       if: ${{ inputs.build-dedup == 'true' }}
       shell: bash
@@ -59,5 +75,9 @@ runs:
       run: |
         set -euo pipefail
         source .venv/bin/activate
-        make -C cdedup PYTHON="$(which python)"
+        if [ -f cdedup.so ]; then
+          echo "Using cached cdedup.so"
+        else
+          make -C cdedup PYTHON="$(which python)"
+        fi
         test -e cdedup.so


### PR DESCRIPTION
## Summary
- add an actions/cache step to restore the compiled cdedup SQLite build outputs keyed by OS, Python version, and source hashes
- reuse cached cdedup.so during setup to avoid rebuilding the extension when artifacts are already present

## Testing
- not run (CI)


------
https://chatgpt.com/codex/tasks/task_e_68f0cd419c50832abe96d8de970df3b6