### PR TITLE
Ensure Windows CI step fails when a test fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,20 @@ jobs:
           $testFiles = @()
           $testFiles += Get-ChildItem -Path tests -Filter 'test_*.py' | Select-Object -ExpandProperty FullName
           $testFiles += Get-ChildItem -Path blobrepo\tests -Filter 'test_*.py' | Select-Object -ExpandProperty FullName
-          foreach ($test in $testFiles) {
-            Write-Host "Executing $test (cachedir $cacheDir)"
-            $env:BOAR_SKIP_DEDUP_TESTS = '1'
-            $env:BOAR_TEST_REMOTE_REPO = '0'
-            python $test
+          try {
+            foreach ($test in $testFiles) {
+              Write-Host "Executing $test (cachedir $cacheDir)"
+              $env:BOAR_SKIP_DEDUP_TESTS = '1'
+              $env:BOAR_TEST_REMOTE_REPO = '0'
+              python $test
+              if ($LASTEXITCODE -ne 0) {
+                throw "Test $test failed with exit code $LASTEXITCODE"
+              }
+            }
           }
-          Remove-Item -LiteralPath $cacheDir -Recurse -Force
+          finally {
+            Remove-Item -LiteralPath $cacheDir -Recurse -Force -ErrorAction SilentlyContinue
+          }
 
   unit-tests:
     name: Unit tests (with dedup)


### PR DESCRIPTION
## Summary
- wrap the Windows unit test loop in a try/finally so the cache directory is always cleaned up
- check `$LASTEXITCODE` after each test execution and raise an error when a test fails

## Testing
- python tests/test_cli_windows_specific.py

------
https://chatgpt.com/codex/tasks/task_e_68f16421046c832aae79c0383462d5b4