### PR TITLE
Ensure pip is available in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,9 @@ jobs:
           python -m venv .venv
           .\.venv\Scripts\Activate.ps1
           python -V
-          pip install -U pip
-          pip install -r requirements.txt
+          python -m ensurepip --upgrade
+          python -m pip install -U pip
+          python -m pip install -r requirements.txt
 
       - name: Run unit tests (no dedup)
         shell: pwsh


### PR DESCRIPTION
## Summary
- ensure the Windows workflow bootstraps pip via `python -m ensurepip --upgrade`
- invoke pip through `python -m pip` so dependency installation works when the module is present only in the interpreter

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f16af3aff4832a93c98ecd1b5270d6