### PR TITLE
Fix Unicode encoding errors on Windows when stdout is redirected

### DIFF
--- a/blobrepo/tests/test_repository.py
+++ b/blobrepo/tests/test_repository.py
@@ -111,7 +111,7 @@ class TestBlobRepo(unittest.TestCase):
         reader = self.repo.get_blob_reader("f749878a7974cf018b5ae2e10c7d8358")
         for n in  range(2500):
             self.assertEqual(reader.read(2**20), megabyte_of_zeroes)
-        self.assertEqual(reader.read(2**20), "")
+        self.assertEqual(reader.read(2**20), b"")
         
 
     def test_secondary_session(self):

--- a/boar
+++ b/boar
@@ -41,7 +41,8 @@ import boarserve
 
 json = get_json_module()
 
-assert sys.version_info >= (3, 8)
+if sys.version_info < (3, 8):
+    sys.exit("ERROR: Boar requires Python 3.8 or later. You are running Python %d.%d." % (sys.version_info[0], sys.version_info[1]))
 
 def execfile(filepath):
     with open(filepath, 'rb') as f:
@@ -947,7 +948,7 @@ def cmd_sessions(args):
         json.dump(names, stdout, indent = 4)
     else:
         for name in names:
-            stdout.write(name.encode("utf-8"))
+            stdout.write(name)
             stdout.write("\n")
 
 def cmd_revisions(args):
@@ -1204,7 +1205,7 @@ def cmd_export(args):
     for exportspec in args:
         blobid, destination = exportspec.split(":")
         assert not os.path.exists(destination)
-        fo = open(destination, "w")
+        fo = open(destination, "wb")
         datasource = front.get_blob(blobid)
         while datasource.bytes_left():
             fo.write(datasource.read(4096))
@@ -1333,7 +1334,7 @@ def cmd_getprop(args):
 
     if options.file:
         try:        
-            with open(options.file, "w") as f:
+            with open(options.file, "w", encoding="utf-8") as f:
                 f.write(property_value)
         except Exception as e:
             raise UserError("Problems writing file %s: %s" % (options.file, e))
@@ -1487,7 +1488,7 @@ def cmd_findlost(args):
             n += 1
             output_path = os.path.join(outputDir, filename + ("(%d)" % n))
             
-        with open(output_path, "w") as f:
+        with open(output_path, "wb") as f:
             datareader = front.get_blob(blobid)
             while datareader.bytes_left() > 0:
                 f.write(datareader.read(2**14))
@@ -1667,6 +1668,16 @@ if __name__ == "__main__":
         msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
         msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
         
+    # Reconfigure stdout/stderr to use UTF-8 encoding with backslashreplace error
+    # handler. This fixes UnicodeEncodeError when printing filenames containing
+    # characters that can't be encoded in the console's default encoding (e.g.,
+    # Cyrillic characters on Windows with cp1252 encoding when stdout is redirected
+    # to a file). Commands that output binary data (like 'cat') use stdout.buffer
+    # directly, so they are not affected by this text encoding configuration.
+    # Note: reconfigure() requires Python 3.7+, but we require 3.8+ anyway.
+    sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace')
+
     sys.argv = list(map(tounicode, sys.argv))
     global ucwd
     ucwd = tounicode(os.getcwd())

--- a/evt/verify-manifests.py
+++ b/evt/verify-manifests.py
@@ -41,10 +41,13 @@ import json
 import re
 
 import sys
-import codecs
 
-# Avoid problems with unicode chars when piping the output of this program
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+# Ensure stdout/stderr use UTF-8 encoding when output is redirected
+# (e.g., on Windows where the default encoding may be cp1252)
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')
+if hasattr(sys.stderr, 'reconfigure'):
+    sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace')
 
 import hashlib
 import os

--- a/jsonrpc.py
+++ b/jsonrpc.py
@@ -204,7 +204,7 @@ class StreamDataSource(DataSource):
         if n == None:
             n = self.bytes_left()
         if self.remaining == 0:
-            return ""
+            return b""
         bytes_to_read = min(n, self.remaining)
         data = self.stream.read(bytes_to_read)
         self.remaining -= bytes_to_read
@@ -238,7 +238,7 @@ class FileDataSource(DataSource):
         if n == None:
             n = self.remaining
         if self.remaining == 0:
-            return ""
+            return b""
         bytes_to_read = min(n, self.remaining)
         data = self.fo.read(bytes_to_read)
         self.remaining -= bytes_to_read

--- a/macrotests/treecheck.py
+++ b/macrotests/treecheck.py
@@ -18,6 +18,13 @@
 import sys
 import os
 
+# Ensure stdout/stderr use UTF-8 encoding when output is redirected
+# (e.g., on Windows where the default encoding may be cp1252)
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')
+if hasattr(sys.stderr, 'reconfigure'):
+    sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace')
+
 if __name__ == '__main__':
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/test_cli_windows_specific.py
+++ b/tests/test_cli_windows_specific.py
@@ -108,6 +108,70 @@ class TestCliWindowsSpecific(unittest.TestCase):
     def testEmpty(self):
         pass
 
+    @unittest.skipUnless(os.name == "nt", "Windows-specific encoding test")
+    def testLocateUnicodeFilenameToFile(self):
+        """Test that locate command handles Unicode filenames correctly when 
+        stdout is redirected to a file (uses cp1252 encoding on Windows).
+        
+        This tests for the bug:
+        UnicodeEncodeError: 'charmap' codec can't encode character '\u0416' 
+        in position 52: character maps to <undefined>
+        
+        The character '\u0416' is Cyrillic capital letter ZHE (Ж), which cannot
+        be represented in Windows-1252 (cp1252) encoding.
+        """
+        # Create a repository and session
+        call([BOAR, "mkrepo", "TESTREPO"])
+        call([BOAR, "--repo", "TESTREPO", "mksession", "TestSession"])
+        call([BOAR, "--repo", "TESTREPO", "co", "TestSession"])
+        
+        # Create a file with ASCII filename but commit it first
+        # to establish a working session
+        ascii_filename = "TestSession/test_file.txt"
+        test_content = "test content for locate"
+        write_file(ascii_filename, test_content)
+        call([BOAR, "ci"], cwd="TestSession")
+        
+        # Create a local file with Cyrillic characters in the filename
+        # '\u0416' is Cyrillic capital letter ZHE (Ж)
+        # This character cannot be encoded in cp1252 (Windows-1252)
+        local_cyrillic_file = "Локальный_Ж_файл.txt"  # Local file with Cyrillic name
+        write_file(local_cyrillic_file, test_content)  # Same content as repo file
+        
+        # The bug occurs when stdout is redirected to a file
+        # Python uses cp1252 encoding on Windows when redirecting to a file
+        output_file = "locate_output.txt"
+        
+        # Use shell=True to simulate the user's command line experience with redirection
+        # This is the scenario that triggers the bug: boar locate ... > file.txt
+        cmd = '"%s" --repo TESTREPO locate TestSession "%s" > "%s" 2>&1' % (
+            BOAR, local_cyrillic_file, output_file)
+        
+        # Run through cmd.exe to get proper redirection behavior
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            cwd=self.testdir
+        )
+        
+        # Check if output file was created
+        output_exists = os.path.exists(output_file)
+        if output_exists:
+            with open(output_file, "rb") as f:
+                output_content = f.read()
+        else:
+            output_content = b""
+        
+        # The command should complete without a UnicodeEncodeError
+        # If the bug exists, the output will contain "UnicodeEncodeError"
+        self.assertNotIn(b"UnicodeEncodeError", output_content,
+            "locate command failed with Unicode encoding error. Output: %s" % output_content)
+        
+        # Also check return code
+        self.assertEqual(result.returncode, 0, 
+            "locate command failed with Unicode filename. Output: %s" % output_content)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/workdir.py
+++ b/workdir.py
@@ -207,7 +207,7 @@ class Workdir(object):
     def export_md5(self):
         assert not os.path.exists("md5sum.txt")
         front = self.get_front()
-        with open("md5sum.txt", "w") as f:
+        with open("md5sum.txt", "w", encoding="utf-8") as f:
             for info in self.get_bloblist(self.revision):
                 f.write(info['md5sum'] +" *" + info['filename'] + "\n")
 


### PR DESCRIPTION
This fixes UnicodeEncodeError crashes that occur when printing filenames containing characters that cannot be encoded in the console's default encoding (e.g., Cyrillic characters on Windows with cp1252 encoding when stdout is redirected to a file).

Changes:
- Configure stdout/stderr to use UTF-8 encoding at startup in main boar CLI
- Fix cmd_sessions to write strings instead of encoded bytes
- Fix cmd_export_blobs and cmd_lostfound to use binary mode for blob output
- Fix cmd_getprop to use UTF-8 encoding when writing to file
- Fix workdir.export_md5() to use UTF-8 encoding
- Fix DataSource.read() to return b'' instead of '' when empty
- Update evt/verify-manifests.py to use modern reconfigure() instead of Python 2 style codecs wrapper
- Add UTF-8 encoding configuration to macrotests/treecheck.py
- Improve Python version check to give clear error message
- Add test case for Unicode filename handling with redirected stdout

The fix ensures that:
- Text output uses UTF-8 with backslashreplace for unencodable characters
- Binary output (like 'cat' command) continues to work via stdout.buffer
- Standalone scripts also handle Unicode output correctly