### PR TITLE
Add --reflink option to update command

### DIFF
--- a/boar
+++ b/boar
@@ -829,12 +829,14 @@ def cmd_import(args):
 
 def cmd_update(args):
     parser = OptionParser(usage="usage: boar update [options]")
-    parser.add_option("-r", "--revision", action="store", dest = "revision", type="int", 
+    parser.add_option("-r", "--revision", action="store", dest = "revision", type="int",
                       help="The revision to update to (defaults to latest)")
-    parser.add_option("-i", "--ignore-errors", action="store_true", dest = "ignore_errors", 
+    parser.add_option("-i", "--ignore-errors", action="store_true", dest = "ignore_errors",
                       help="Do not abort the update if there are errors while writing.")
-    parser.add_option("-c", "--ignore-changes", action="store_true", dest = "ignore_changes", 
+    parser.add_option("-c", "--ignore-changes", action="store_true", dest = "ignore_changes",
                       help="Update the workdir revision but do not update the workdir contents.")
+    parser.add_option("-L", "--reflink", dest = "reflink", action="store_true",
+                      help="Create reflinks instead of copying the data (only within same device, requires filesystem support).")
     parser.add_option("-q", "--quiet", dest = "quiet", action="store_true", default = False,
                       help="Do not print any progress information")
     (options, args) = parser.parse_args(args)
@@ -844,6 +846,13 @@ def cmd_update(args):
     if not wd:
         raise UserError(not_a_workdir_msg)
     wd.use_progress_printer(not options.quiet)
+    if options.reflink:
+        if os.name == "nt":
+            raise UserError("Reflinks can not be used on windows")
+        if not (wd.repoUrl.startswith("/") or wd.repoUrl.startswith("file://")):
+            raise UserError("Reflinks can only be used with a local repository specification")
+        if wd.front.deduplication_enabled():
+            raise UserError("Reflinks can not be used with deduplicated repositories")
     new_revision = options.revision
     old_revision = wd.revision
     deleted_old_revision = wd.front.is_deleted(old_revision)
@@ -861,7 +870,8 @@ def cmd_update(args):
         wd.update_revision(options.revision)
     else:
         have_added_or_modified = wd.update(
-            old_revision = old_revision, new_revision = new_revision, ignore_errors = options.ignore_errors)
+            old_revision = old_revision, new_revision = new_revision,
+            ignore_errors = options.ignore_errors, reflink = options.reflink)
 
         if have_added_or_modified and deleted_old_revision:
             warn("The old revision that you are updating to was deleted from the repository. " +

--- a/workdir.py
+++ b/workdir.py
@@ -249,11 +249,16 @@ class Workdir(object):
             if overwrite and os.path.exists(target_path):
                 # reflink() requires the target to not exist, so write
                 # to a sibling tempfile and rename into place atomically.
-                tmp_path = target_path + ".boar.reflink.tmp"
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
-                reflink(blob_path, tmp_path)
-                os.rename(tmp_path, target_path)
+                fd, tmp_path = tempfile.mkstemp(prefix=".boar-reflink-", dir=target_dir)
+                os.close(fd)
+                os.remove(tmp_path)
+                try:
+                    reflink(blob_path, tmp_path)
+                    os.rename(tmp_path, target_path)
+                except:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+                    raise
             else:
                 reflink(blob_path, target_path)
         else:

--- a/workdir.py
+++ b/workdir.py
@@ -246,7 +246,16 @@ class Workdir(object):
             target_dir = os.path.dirname(target_path)
             if not os.path.exists(target_dir):
                 os.makedirs(target_dir)
-            reflink(blob_path, target_path)
+            if overwrite and os.path.exists(target_path):
+                # reflink() requires the target to not exist, so write
+                # to a sibling tempfile and rename into place atomically.
+                tmp_path = target_path + ".boar.reflink.tmp"
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                reflink(blob_path, tmp_path)
+                os.rename(tmp_path, target_path)
+            else:
+                reflink(blob_path, target_path)
         else:
             fetch_blob(self.get_front(), md5, target_path, overwrite = overwrite)
 
@@ -269,7 +278,7 @@ class Workdir(object):
         assert not self.front.is_deleted(new_revision) # Should not be possible, but could potentially cause deletion of workdir files
         return self.update(self.revision, new_revision, ignore_errors)
 
-    def update(self, old_revision, new_revision, ignore_errors = False):
+    def update(self, old_revision, new_revision, ignore_errors = False, reflink = False):
         """ Apply the changes from old_revision to
         new_revision. Differences in the workdir from old_revision
         will be considered modifications and will not be
@@ -296,7 +305,10 @@ class Workdir(object):
             if not os.path.exists(target_abspath) or self.cached_md5sum(target_wdpath) != b['md5sum']:
                 print("Updating:", b['filename'], file=log)
                 try:
-                    fetch_blob(front, b['md5sum'], target_abspath, overwrite = True)
+                    if reflink:
+                        self.fetch_file(b['filename'], b['md5sum'], overwrite = True, reflink = True)
+                    else:
+                        fetch_blob(front, b['md5sum'], target_abspath, overwrite = True)
                 except (IOError, OSError) as e:
                     print("Could not update file %s: %s" % (b['filename'], e.strerror), file=log)
                     if not ignore_errors:


### PR DESCRIPTION
## Summary
- Add `-L/--reflink` to `boar update`, mirroring the existing `co --reflink` behavior (no Windows, local repo only, no dedup)
- Plumb the flag through `Workdir.update` into `fetch_file`, which now handles overwriting an existing target by reflinking to a sibling tempfile and renaming into place atomically (the underlying `reflink()` call requires the target not to exist)

## Test plan
- [x] `boar update --help` shows the new option
- [x] On a reflink-capable filesystem (XFS), update overwrites an existing file via reflink and the resulting file shares an extent with the blob (verified with `filefrag -v` showing `flags: shared` and matching `physical_offset`)
- [x] Behavior matches `co --reflink` on a non-reflink filesystem (both fail with `EOPNOTSUPP` at the same syscall)
- [x] Modified files are still skipped during update (existing `modified_files` check is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)