### PR TITLE
Restore file mtime on checkout and update (issue 88)

### DIFF
--- a/boar
+++ b/boar
@@ -837,6 +837,8 @@ def cmd_update(args):
                       help="Update the workdir revision but do not update the workdir contents.")
     parser.add_option("-L", "--reflink", dest = "reflink", action="store_true",
                       help="Create reflinks instead of copying the data (only within same device, requires filesystem support).")
+    parser.add_option("--no-restore-mtime", dest = "restore_mtime", action="store_false", default = True,
+                      help="Do not restore file modification times from the snapshot. By default, mtimes are restored.")
     parser.add_option("-q", "--quiet", dest = "quiet", action="store_true", default = False,
                       help="Do not print any progress information")
     (options, args) = parser.parse_args(args)
@@ -871,7 +873,8 @@ def cmd_update(args):
     else:
         have_added_or_modified = wd.update(
             old_revision = old_revision, new_revision = new_revision,
-            ignore_errors = options.ignore_errors, reflink = options.reflink)
+            ignore_errors = options.ignore_errors, reflink = options.reflink,
+            restore_mtime = options.restore_mtime)
 
         if have_added_or_modified and deleted_old_revision:
             warn("The old revision that you are updating to was deleted from the repository. " +
@@ -1238,6 +1241,8 @@ def cmd_co(args):
                       help="Create symlinks to the repository instead of copying the data. (DANGEROUS)")
     parser.add_option("-L", "--reflink", dest = "reflink", action="store_true",
                       help="Create reflinks instead of copying the data (only within same device, requires filesystem support).")
+    parser.add_option("--no-restore-mtime", dest = "restore_mtime", action="store_false", default = True,
+                      help="Do not restore file modification times from the snapshot. By default, mtimes are restored.")
 
     (options, args) = parser.parse_args(args)
     if not args:
@@ -1284,7 +1289,8 @@ def cmd_co(args):
 
     os.mkdir(workdir_path)
     wd = workdir.Workdir(repourl, session_name, offset, sid, workdir_path, front = front)
-    wd.checkout(symlink=options.symlink, reflink=options.reflink)
+    wd.checkout(symlink=options.symlink, reflink=options.reflink,
+                restore_mtime=options.restore_mtime)
 
 def cmd_setprop(args):
     parser = OptionParser(usage="usage: boar setprop [options] <session name> <property> [new value]")

--- a/macrotests/test_issue88.sh
+++ b/macrotests/test_issue88.sh
@@ -75,12 +75,16 @@ grep -E "^[MAD?] " st.txt && {
 # Symlink mode should silently skip mtime restoration (would otherwise
 # mutate the shared blob in the repo). The link target's mtime is the
 # blob's mtime, which is the time it was written to the repo, not the
-# original file mtime.
-$BOAR co -l TestMtime co_symlink >/dev/null
-test -L co_symlink/foo.txt || {
-    echo "Expected symlink"; exit 1; }
-# Verify the symlink points at a repo blob (blob path contains "/blobs/").
-readlink co_symlink/foo.txt | grep -q "/blobs/" || {
-    echo "Symlink does not point to repo blob"; exit 1; }
+# original file mtime. Symlink mode requires direct access to repo
+# internals (front.repo.has_raw_blob / get_blob_path) which are not
+# exposed over RPC, so skip this part under simulated remote.
+if [ -z "$BOAR_TEST_REMOTE_REPO" ] || [ "$BOAR_TEST_REMOTE_REPO" = "0" ]; then
+    $BOAR co -l TestMtime co_symlink >/dev/null
+    test -L co_symlink/foo.txt || {
+        echo "Expected symlink"; exit 1; }
+    # Verify the symlink points at a repo blob (blob path contains "/blobs/").
+    readlink co_symlink/foo.txt | grep -q "/blobs/" || {
+        echo "Symlink does not point to repo blob"; exit 1; }
+fi
 
 exit 0

--- a/macrotests/test_issue88.sh
+++ b/macrotests/test_issue88.sh
@@ -1,0 +1,86 @@
+#
+# Issue 88: File mtimes should be restored on checkout/update.
+#
+# Verify that the mtime captured at commit time is reapplied to the
+# file when it is later checked out or updated, and that the
+# behaviour can be disabled with --no-restore-mtime.
+#
+
+set -e
+
+export REPO_PATH=`pwd`/TESTREPO
+$BOAR mkrepo $REPO_PATH
+$BOAR mksession TestMtime
+
+# Pin known mtimes that are clearly different from "now". Using two
+# distinct historical timestamps lets us tell which revision a file
+# came from after a checkout or update.
+TS1="2015-06-02 12:01:06"
+TS2="2020-01-15 03:14:07"
+
+mkdir src1
+echo "first contents" >src1/foo.txt
+echo "first contents of bar" >src1/bar.txt
+touch -d "$TS1" src1/foo.txt src1/bar.txt
+EXPECTED1=`stat -c '%Y' src1/foo.txt`
+
+$BOAR import -Wq src1 TestMtime
+
+# --- Checkout (default: restore mtime) ---
+$BOAR co TestMtime co_default >/dev/null
+GOT=`stat -c '%Y' co_default/foo.txt`
+test "$GOT" = "$EXPECTED1" || {
+    echo "Checkout did not restore mtime (expected $EXPECTED1, got $GOT)"; exit 1; }
+
+# --- Checkout with --no-restore-mtime ---
+$BOAR co --no-restore-mtime TestMtime co_norestore >/dev/null
+GOT=`stat -c '%Y' co_norestore/foo.txt`
+test "$GOT" = "$EXPECTED1" && {
+    echo "--no-restore-mtime should not have restored mtime"; exit 1; }
+
+# Modifying a restored file should still be detected as a real
+# modification (i.e. the workdir checksum cache must remain coherent
+# after we adjust the mtime).
+echo "modified locally" >co_default/foo.txt
+(cd co_default && $BOAR status) | grep -E "^M foo.txt" || {
+    echo "Modification of restored file was not detected"; exit 1; }
+# Restore the file so the rest of the test starts from a clean state.
+echo "first contents" >co_default/foo.txt
+touch -d "$TS1" co_default/foo.txt
+
+# --- Commit a new revision with a different historical mtime, then update ---
+$BOAR co TestMtime workdir2 >/dev/null
+echo "second contents" >workdir2/foo.txt
+touch -d "$TS2" workdir2/foo.txt
+EXPECTED2=`stat -c '%Y' workdir2/foo.txt`
+(cd workdir2 && $BOAR ci -q)
+
+# Default update should restore mtime.
+(cd co_default && $BOAR update) >/dev/null
+GOT=`stat -c '%Y' co_default/foo.txt`
+test "$GOT" = "$EXPECTED2" || {
+    echo "Update did not restore mtime (expected $EXPECTED2, got $GOT)"; exit 1; }
+
+# --no-restore-mtime should leave the file with a recent mtime.
+(cd co_norestore && $BOAR update --no-restore-mtime) >/dev/null
+GOT=`stat -c '%Y' co_norestore/foo.txt`
+test "$GOT" = "$EXPECTED2" && {
+    echo "Update --no-restore-mtime should not have restored mtime"; exit 1; }
+
+# After mtime restore, no spurious modifications should be reported.
+(cd co_default && $BOAR status -q) >st.txt 2>&1
+grep -E "^[MAD?] " st.txt && {
+    cat st.txt; echo "Workdir reported spurious changes after update"; exit 1; }
+
+# Symlink mode should silently skip mtime restoration (would otherwise
+# mutate the shared blob in the repo). The link target's mtime is the
+# blob's mtime, which is the time it was written to the repo, not the
+# original file mtime.
+$BOAR co -l TestMtime co_symlink >/dev/null
+test -L co_symlink/foo.txt || {
+    echo "Expected symlink"; exit 1; }
+# Verify the symlink points at a repo blob (blob path contains "/blobs/").
+readlink co_symlink/foo.txt | grep -q "/blobs/" || {
+    echo "Symlink does not point to repo blob"; exit 1; }
+
+exit 0

--- a/workdir.py
+++ b/workdir.py
@@ -211,7 +211,7 @@ class Workdir(object):
             for info in self.get_bloblist(self.revision):
                 f.write(info['md5sum'] +" *" + info['filename'] + "\n")
 
-    def checkout(self, write_meta = True, symlink = False, reflink = False):
+    def checkout(self, write_meta = True, symlink = False, reflink = False, restore_mtime = True):
         assert os.path.exists(self.root) and os.path.isdir(self.root)
         assert not (symlink and reflink)
         front = self.get_front()
@@ -223,9 +223,11 @@ class Workdir(object):
         for info in sorted_bloblist(self.get_bloblist(self.revision)):
             if not is_child_path(self.offset, info['filename']):
                 continue
-            self.fetch_file(info['filename'], info['md5sum'], overwrite = False, symlink = symlink, reflink = reflink)
+            mtime = info.get('mtime') if restore_mtime else None
+            self.fetch_file(info['filename'], info['md5sum'], overwrite = False,
+                            symlink = symlink, reflink = reflink, mtime = mtime)
 
-    def fetch_file(self, session_path, md5, overwrite = False, symlink = False, reflink = False):
+    def fetch_file(self, session_path, md5, overwrite = False, symlink = False, reflink = False, mtime = None):
         assert is_child_path(self.offset, session_path)
         target = strip_path_offset(self.offset, session_path)
         target_path = os.path.join(self.root, target)
@@ -238,6 +240,10 @@ class Workdir(object):
             if not os.path.exists(target_dir):
                 os.makedirs(target_dir)
             os.symlink(blob_path, target_path)
+            # Skip mtime restoration: target is a symlink to the shared
+            # blob in the repo, and os.utime would follow the link and
+            # mutate the blob.
+            return
         elif reflink:
             from reflink import reflink
             assert self.get_front().repo.has_raw_blob(md5)
@@ -261,8 +267,29 @@ class Workdir(object):
                     raise
             else:
                 reflink(blob_path, target_path)
+            if mtime is not None:
+                self._apply_mtime(target, target_path, md5, mtime)
         else:
-            fetch_blob(self.get_front(), md5, target_path, overwrite = overwrite)
+            fetch_blob(self.get_front(), md5, target_path, overwrite = overwrite, mtime = mtime)
+            if mtime is not None:
+                self._apply_cache_for_mtime(target, target_path, md5)
+
+    def _apply_mtime(self, wd_relative_path, target_path, md5, mtime):
+        """Set the file's mtime to the given value and refresh the
+        checksum cache so that the new mtime maps to the known md5."""
+        os.utime(target_path, (mtime, mtime))
+        self._apply_cache_for_mtime(wd_relative_path, target_path, md5)
+
+    def _apply_cache_for_mtime(self, wd_relative_path, target_path, md5):
+        """Refresh the checksum cache entry for the file at
+        target_path. Called after a file has been written and (possibly)
+        had its mtime adjusted, so that subsequent commands can find the
+        cached checksum without re-reading the file."""
+        try:
+            new_mtime = os.stat(target_path).st_mtime
+        except OSError:
+            return
+        self.sqlcache.set(wd_relative_path, new_mtime, md5)
 
     def update_revision(self, new_revision = None):
         assert new_revision == None or isinstance(new_revision, int)
@@ -283,7 +310,7 @@ class Workdir(object):
         assert not self.front.is_deleted(new_revision) # Should not be possible, but could potentially cause deletion of workdir files
         return self.update(self.revision, new_revision, ignore_errors)
 
-    def update(self, old_revision, new_revision, ignore_errors = False, reflink = False):
+    def update(self, old_revision, new_revision, ignore_errors = False, reflink = False, restore_mtime = True):
         """ Apply the changes from old_revision to
         new_revision. Differences in the workdir from old_revision
         will be considered modifications and will not be
@@ -307,13 +334,17 @@ class Workdir(object):
                 continue
             target_wdpath = strip_path_offset(self.offset, b['filename'])
             target_abspath = os.path.join(self.root, target_wdpath)
+            mtime = b.get('mtime') if restore_mtime else None
             if not os.path.exists(target_abspath) or self.cached_md5sum(target_wdpath) != b['md5sum']:
                 print("Updating:", b['filename'], file=log)
                 try:
                     if reflink:
-                        self.fetch_file(b['filename'], b['md5sum'], overwrite = True, reflink = True)
+                        self.fetch_file(b['filename'], b['md5sum'], overwrite = True,
+                                        reflink = True, mtime = mtime)
                     else:
-                        fetch_blob(front, b['md5sum'], target_abspath, overwrite = True)
+                        fetch_blob(front, b['md5sum'], target_abspath, overwrite = True, mtime = mtime)
+                        if mtime is not None:
+                            self._apply_cache_for_mtime(target_wdpath, target_abspath, b['md5sum'])
                 except (IOError, OSError) as e:
                     print("Could not update file %s: %s" % (b['filename'], e.strerror), file=log)
                     if not ignore_errors:
@@ -829,7 +860,7 @@ def create_blobinfo(abspath, sessionpath, md5sum):
     blobinfo["size"] = st[stat.ST_SIZE]
     return blobinfo
 
-def fetch_blob(front, blobname, target_path, overwrite = False):
+def fetch_blob(front, blobname, target_path, overwrite = False, mtime = None):
     assert overwrite or not os.path.exists(target_path)
     target_dir = os.path.dirname(target_path)
     if not os.path.exists(target_dir):
@@ -852,6 +883,8 @@ def fetch_blob(front, blobname, target_path, overwrite = False):
         if os.path.exists(tmpfile):
             os.remove(tmpfile)
         raise
+    if mtime is not None:
+        os.utime(target_path, (mtime, mtime))
 
 def bloblist_to_dict(bloblist):
     d = {}


### PR DESCRIPTION
## Summary

- Restore file mtime on `boar co` and `boar update` by default. New `--no-restore-mtime` flag to opt out. Closes #88.
- mtime data has always been captured into `bloblist.json` (verified back to v0 regression archives) but was never reapplied on checkout — photo/media libraries lost their "last modified" timestamps as the original reporter described.
- ctime intentionally not restored: Linux can't set inode-change-time via standard syscalls, Windows would need `ctypes`/`SetFileTime` outside stdlib. The ctime field is still preserved in the bloblist for a possible future Windows-specific path.

## Behaviour details

- **Symlink mode** (`co -l`): silently skips mtime restoration — `os.utime` follows symlinks and would mutate the shared blob in the repo.
- **Reflink mode** (`co -L` / `update -L`): does restore mtime — reflink creates a fresh inode (CoW), so it's safe.
- **Fingerprints unaffected**: `bloblist_fingerprint` hashes only filename + md5sum.
- After `os.utime`, the workdir checksum cache is refreshed with the new mtime so the next `status`/`ci` doesn't re-checksum every file.

## Test plan

- [x] New `macrotests/test_issue88.sh` covers checkout, update, `--no-restore-mtime`, cache coherence after restore, and the symlink skip
- [x] All 87 unit tests pass
- [x] All 35 non-dedup macrotests pass (test_deduplication.sh requires the unbuilt C extension and was already failing before this change)
- [x] Existing `tests/test_cli.py` already strips `mtime` from contents-output comparisons; passes unchanged
- [x] Manual sanity: timestamps from 2015/2020 round-trip through `import` → `co` → `update`; cache stays coherent (modifying a restored file is still detected as `M`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)