### PR TITLE
Fix is_md5sum to reject trailing newline

### DIFF
--- a/common.py
+++ b/common.py
@@ -97,9 +97,13 @@ def read_json(filename):
 specific for any project """
 
 def is_md5sum(s):
+    # Use fullmatch (not match with $) because $ matches before a final \n,
+    # which would allow a trailing newline to pass validation. The md5sum
+    # often gates path construction, so a sloppy match could end up creating
+    # files with newline-terminated names inside the repo.
     b = str2bytes(s)
     try:
-        return re.match(b"^[a-f0-9]{32}$", b) != None
+        return re.fullmatch(b"[a-f0-9]{32}", b) != None
     except TypeError:
         return False
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -294,6 +294,21 @@ class TestMisc(unittest.TestCase):
         test("abc", "a", "")
         test("a", "abc", "")
 
+    def test_is_md5sum(self):
+        valid = "a" * 32
+        self.assertTrue(common.is_md5sum(valid))
+        self.assertTrue(common.is_md5sum(valid.encode("ascii")))
+        # Anchored validation: trailing or embedded whitespace/control chars
+        # must not pass, even though Python's "$" would match before a final \n.
+        self.assertFalse(common.is_md5sum(valid + "\n"))
+        self.assertFalse(common.is_md5sum(valid + "\r\n"))
+        self.assertFalse(common.is_md5sum(valid + "/"))
+        self.assertFalse(common.is_md5sum("/" + valid[1:]))
+        self.assertFalse(common.is_md5sum(valid[:-1]))
+        self.assertFalse(common.is_md5sum(valid + "a"))
+        self.assertFalse(common.is_md5sum(valid.upper()))
+        self.assertFalse(common.is_md5sum(""))
+
     def test_invert_dict(self):
         inv_d = common.invert_dict({
             "k1": "v1",


### PR DESCRIPTION
## Summary

`is_md5sum` used `re.match(b"^[a-f0-9]{32}$", b)`. Python's `$` in a non-multiline pattern matches both end-of-string **and** the position immediately before a final `\n`, so an md5sum-shaped string with a trailing newline passed validation.

`is_md5sum` is the gate in front of every place the code joins an externally-supplied checksum into a filesystem path (`get_blob_path`, `get_recipe_path`, the fingerprint marker name in `_NaiveSessionWriter.commit`, queue/integration logic, etc.). A `\n` slipping through doesn't enable path traversal — the path still resolves inside `repopath/blobs/aa/...` — but it would create files with newline-terminated names inside the repo and silently break the `md5sum`-style invariants in `Transaction.integrate_files`, the recovery shell semantics described in `recovery.txt`, and any downstream tool that line-splits on filenames.

Switching to `re.fullmatch` anchors against the full string and drops the now-redundant `^...$`.

## Test plan

- [x] Added `TestMisc.test_is_md5sum` in `tests/test_common.py` covering the trailing-`\n`, trailing-`\r\n`, leading-`/`, off-by-one length, uppercase-hex, and empty-string cases.
- [x] `python3 tests/test_common.py` — 28 tests pass.
- [x] `python3 -m unittest discover -s blobrepo/tests` — 11 tests pass.
- [x] Existing inline assertion `assert is_md5sum("7df642b2ff939fa4ba27a3eb4009ca67")` at import time still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)