### PR TITLE
Document and harden cat/contents/stats/sessions/revisions/truncate

### DIFF
--- a/boar
+++ b/boar
@@ -63,9 +63,11 @@ def print_help():
 Usage: boar <command> 
 
 Commands:
+cat       Print the contents of a file or blob to standard output
 ci        Commit changes in a work directory
 clone     Create or update a clone of a repository
 co        Check out files from the repository
+contents  Show the file listing of a snapshot, with checksums
 diffrepo  Check if two repositories are identical
 getprop   Get session properties, such as file ignore lists
 info      Show some information about the current workdir
@@ -76,9 +78,13 @@ log       Show changes and log messages
 ls        Show the contents of a specific sub directory of a snapshot
 mkrepo    Create a new repository
 mksession Create a new session
+revisions List the revisions of a session
+sessions  List all session names in the repository
 setprop   Set session properties, such as file ignore lists
 serve     Make a repository accessible over the network
+stats     Show statistics about the repository
 status    List any changes in the current work directory
+truncate  Remove the history of a session, keeping only its latest revision (DESTRUCTIVE)
 update    Update the current work directory from the repository
 verify    Verify the integrity of the repository
 
@@ -1007,7 +1013,7 @@ def cmd_contents(args):
         raise UserError("Too many arguments")
     session_name = args.pop(0)
     if options.punycode:
-        session_name = str(session_name).decode("punycode")
+        session_name = session_name.encode("ascii").decode("punycode")
     stdout = dedicated_stdout()
     globals()["suppress_finishmessage"] = True
     front = connect_to_repo(get_repo_url())
@@ -1026,13 +1032,13 @@ def cmd_contents(args):
     dump['revision'] = sessionId
     dump['fingerprint'] = front.get_session_fingerprint(sessionId)
     entries = []
+    dump['files'] = entries
     for bi in front.get_session_bloblist(sessionId):
         entries.append(OrderedDict([('filename', bi['filename']),
                                     ('size', bi['size']),
                                     ('md5', bi['md5sum']),
                                     ('mtime', bi['mtime'])
         ]))
-        dump['files'] = entries
 
     if options.md5sum:
         for bi in dump['files']:
@@ -1153,7 +1159,7 @@ def cmd_cat(args):
         while args:
             path = args.pop(0)
             if options.punycode:
-                path = str(path).decode("punycode")
+                path = path.encode("ascii").decode("punycode")
             session_name, session_path = parse_sessionpath(path)
             if options.revision:
                 if options.revision not in front.get_session_ids(session_name):

--- a/macrotests/test_cat.sh
+++ b/macrotests/test_cat.sh
@@ -56,6 +56,10 @@ $BOAR cat RäksmörgåsSession/nonexisting.txt >output.txt 2>&1 && {
 txtmatch.py expected.txt output.txt || { echo "Cat non-existing file gave unexpected output"; exit 1; }
 
 
+# The --punycode option lets the session/path be given in punycode form.
+PUNYPATH=$($PYTHON_BINARY -c "print('RäksmörgåsSession/r3.txt'.encode('punycode').decode('ascii'))")
+$BOAR cat --punycode "$PUNYPATH" | grep "Rev 3" || { echo "Unexpected output for cat --punycode"; exit 1; }
+
 
 echo "All is well"
 true

--- a/macrotests/test_contents.sh
+++ b/macrotests/test_contents.sh
@@ -1,0 +1,54 @@
+# Test that the contents command behaves as expected.
+set -e
+
+export REPO_PATH=`pwd`/TESTREPO
+$BOAR mkrepo $REPO_PATH
+$BOAR mksession RäksmörgåsSession
+$BOAR co RäksmörgåsSession
+
+echo "Rev 2 file" >RäksmörgåsSession/r2.txt
+echo "keep me" >RäksmörgåsSession/keep.txt
+(cd RäksmörgåsSession && $BOAR ci -q)
+
+echo "Rev 3 file" >RäksmörgåsSession/r3.txt
+(cd RäksmörgåsSession && $BOAR ci -q)
+
+# --md5sum of the latest revision must list all three files with correct
+# checksums. Normalize boar's "<md5> *<name>" and md5sum's "<md5>  <name>"
+# to a common form and compare sorted.
+(cd RäksmörgåsSession && md5sum keep.txt r2.txt r3.txt) | sed 's/  / /' | sort >expected.txt
+$BOAR contents --md5sum RäksmörgåsSession | sed 's/ \*/ /' | sort >output.txt
+txtmatch.py expected.txt output.txt || { echo "Unexpected --md5sum output for latest revision"; exit 1; }
+
+# -r selects an older revision (rev 2 has only two files).
+(cd RäksmörgåsSession && md5sum keep.txt r2.txt) | sed 's/  / /' | sort >expected.txt
+$BOAR contents -r 2 --md5sum RäksmörgåsSession | sed 's/ \*/ /' | sort >output.txt
+txtmatch.py expected.txt output.txt || { echo "Unexpected --md5sum output for -r 2"; exit 1; }
+
+# --punycode lets the session name be given in punycode form. It must produce
+# the exact same result as the plain name.
+PUNYNAME=$($PYTHON_BINARY -c "print('RäksmörgåsSession'.encode('punycode').decode('ascii'))")
+$BOAR contents RäksmörgåsSession >plain.txt
+$BOAR contents --punycode "$PUNYNAME" >puny.txt
+txtmatch.py plain.txt puny.txt || { echo "--punycode gave different output than plain name"; exit 1; }
+
+# An empty session must not crash: --md5sum gives no output, json gives [] files.
+$BOAR mksession EmptySession
+$BOAR contents --md5sum EmptySession >output.txt || { echo "contents --md5sum failed on empty session"; exit 1; }
+test ! -s output.txt || { cat output.txt; echo "Empty session should produce no --md5sum lines"; exit 1; }
+
+cat >expected.txt <<EOF
+    "files": []
+EOF
+$BOAR contents EmptySession | grep '"files"' >output.txt || { echo "contents (json) failed on empty session"; exit 1; }
+txtmatch.py expected.txt output.txt || { echo "Empty session json should have an empty files list"; exit 1; }
+
+# A non-existing session must fail with a friendly error.
+cat >expected.txt <<EOF
+ERROR: No such session found: NoSuchSession
+EOF
+$BOAR contents NoSuchSession >output.txt 2>&1 && { cat output.txt; echo "contents of non-existing session should fail"; exit 1; }
+txtmatch.py expected.txt output.txt || { echo "Unexpected error message for non-existing session"; exit 1; }
+
+echo "All is well"
+true


### PR DESCRIPTION
## Summary

Several working commands were missing from `boar --help`. This makes the mature ones first-class citizens and fixes two latent bugs in them.

**Documented in `--help`:** `cat`, `contents`, `stats`, `sessions`, `revisions`, and `truncate` (the latter flagged `(DESTRUCTIVE)` since it irreversibly drops history).

**Bug fixes in the now-documented commands:**
- `--punycode` in `cat` and `contents` used the Python 2 idiom `str(x).decode("punycode")`, which always raised `AttributeError` under Python 3. Now decodes via `x.encode("ascii").decode("punycode")`.
- `contents` only set `dump['files']` inside the bloblist loop, so an empty snapshot left the key unset and crashed `contents --md5sum` with a `KeyError`. Initialized before the loop.

## Tests
- Added a `--punycode` case to `macrotests/test_cat.sh`.
- Added `macrotests/test_contents.sh` (the `contents` command previously had no macrotest) covering `--md5sum`, `-r`, `--punycode`, empty sessions, and the no-such-session error.
- All pass locally and in simulated-remote mode; `tests/test_cli.py` and the truncate/mksession/list/ls macrotests still pass.

## Notes
- `sessions`/`revisions` overlap with `list` but are kept as the cleaner script-friendly path (plain / `-j` output).
- The `@beta` commands and the half-baked `find`/`export` were intentionally left undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)