### PR TITLE
Fix latent Python 3 bytes/str and refactoring bugs

### DIFF
--- a/blobrepo/blobreader.py
+++ b/blobrepo/blobreader.py
@@ -151,7 +151,7 @@ def benchmark():
             return blob_path
     block_size = 65536
     block_count = 10000
-    blob_fo.write("\0" * block_size)
+    blob_fo.write(b"\0" * block_size)
     recipe = {"md5sum": "00000000000000000000000000000000",
               "method": "concat",
               "size": block_size * block_count,

--- a/front.py
+++ b/front.py
@@ -643,7 +643,7 @@ class DryRunFront(object):
         return self.realfront.get_session_ids()
 
     def get_session_info(self, id):
-        return self.realfront.get_session_properties(id)['client_data']
+        return self.realfront.get_session_info(id)
 
     def get_session_bloblist(self, id):
         return self.realfront.get_session_bloblist(id)
@@ -661,7 +661,7 @@ class DryRunFront(object):
         return []
 
     def add_blob_data_streamed(self, blob_md5=None, progress_callback=None, datasource=None):
-        while datasource.remaining:
+        while datasource.bytes_left():
             datasource.read(2**12)
 
     def blob_finished(self, blob_md5):

--- a/jsonrpc.py
+++ b/jsonrpc.py
@@ -644,7 +644,7 @@ class BoarMessageServer(object):
                     if is_progress_packet:
                         raise ConnectionLost("Got a progress packet from the client")
                 except WrongProtocolVersion as e:
-                    self.__send_result("['Dummy message. The response header should tell the client that the server is of an incompatible version']")
+                    self.__send_result(str2bytes("['Dummy message. The response header should tell the client that the server is of an incompatible version']"))
                     break
                 except ConnectionLost as e:
                     self.log("Disconnected: %s" % e)

--- a/workdir.py
+++ b/workdir.py
@@ -125,7 +125,7 @@ class Workdir(object):
         except UndecodableFilenameException as e:
             raise UserError("Found a filename that is illegal under the current file system encoding (%s): '%s'" %
                             (sys.getfilesystemencoding(), e.human_readable_name))
-        self.tree_csums == None
+        self.tree_csums = None
         self.__reload_manifests()
 
     def __reload_manifests(self):


### PR DESCRIPTION
Found during a pre-rename audit of the Python 2 → 3 migration. The migration is essentially complete and solid — every file compiles clean under Python 3 and the full unit suite passes — but five latent bugs were hiding in error paths, dry-run paths, and dev helpers that the tests don't exercise.

## bytes / str (genuine Py3 migration bugs)

- **`jsonrpc.py`** — the `WrongProtocolVersion` handler passed a `str` straight to `__send_result()`, which writes to a **binary** stream → `TypeError`. This is the cross-version handshake path (exactly what fires when an old and a new client/server meet). Now encoded with `str2bytes()`, like the normal result path already does.
- **`blobrepo/blobreader.py`** — `benchmark()` wrote a `str` to a binary temp file (`"\0"` → `b"\0"`). Dev helper only, but a real `TypeError`.

## refactoring leftovers (not Py2-specific, but real)

- **`workdir.py`** — `__reload_tree()` had `self.tree_csums == None` (comparison) instead of `= None`, so the checksum cache was **never invalidated** on a tree reload and could return stale containment results.
- **`front.py`** — `DryRunFront.get_session_info()` called the non-existent `realfront.get_session_properties()`; now delegates to `get_session_info()` (which already returns `client_data`).
- **`front.py`** — `DryRunFront.add_blob_data_streamed()` looped on the missing attribute `datasource.remaining`; now uses `datasource.bytes_left()`.

## Verification

- All four files compile clean under Python 3.
- Core unit suites pass (test_common, test_boar_common, test_checksum_cache, test_workdir, test_deduplication, test_cli, test_repository — 123 tests).
- Added targeted functional checks confirming the previously-`AttributeError`ing `DryRunFront.get_session_info` / `add_blob_data_streamed` paths now work and the handshake payload is bytes.

Cosmetic / vestigial Py2 leftovers (py2exe import guard, the dead Python 2.7 json-bug check, the vestigial simplejson preference, dead `dictkeyclean` ASCII validation, stale comments) were catalogued separately and intentionally left out of this PR to keep it to behavioral fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)