### PR TITLE
Add per-repository maximum blob size (split large files via recipes)

### DIFF
--- a/blobrepo/repository.py
+++ b/blobrepo/repository.py
@@ -50,6 +50,12 @@ DERIVED_SHA256_DIR = os.path.join(DERIVED_DIR, "sha256")
 DERIVED_BLOCKS_DIR = os.path.join(DERIVED_DIR, "blocks")
 DERIVED_BLOCKS_DB = os.path.join(DERIVED_BLOCKS_DIR, "blocks.db")
 DELETE_MARKER = "deleted.json"
+MAXBLOBSIZE_FILE = "maxblobsize.txt"
+
+# The smallest maximum blob size that may be configured for a
+# repository. It must be at least one deduplication block so that the
+# splitting machinery and block deduplication can coexist.
+MIN_MAX_BLOB_SIZE = 2**16
 
 REPO_DIRS_V0 = (QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR)
 REPO_DIRS_V1 = (QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR,\
@@ -95,6 +101,51 @@ blobs/bc/bc7b0fb8c2e096693acacbd6cb070f16 since the checksum starts
 with the letters "bc". The filename "testimage.jpg" is discarded. Such
 an anonymized file is called a "blob" in this document.
 
+== The recipes ==
+
+Not every blob is necessarily stored as a single raw file under
+"blobs". A blob may instead be described by a "recipe" found under the
+"recipes" directory. Recipes are used both for deduplication and to
+split large files into smaller pieces, so that a repository can be
+stored on a filesystem with a maximum file size (for instance, a
+repository on a FAT32 disk that must avoid files larger than a few
+gigabytes).
+
+Like blobs, recipes are named after the md5 checksum of the data they
+reconstruct, sorted into sub directories by the first two characters
+of the name, but with the suffix ".recipe". For instance, the recipe
+for a blob with the checksum bc7b0fb8c2e096693acacbd6cb070f16 is
+stored in recipes/bc/bc7b0fb8c2e096693acacbd6cb070f16.recipe .
+
+A recipe is a JSON document of the following form:
+
+{
+    "method": "concat",
+    "md5sum": "<checksum of the reconstructed blob>",
+    "size": <size in bytes of the reconstructed blob>,
+    "pieces": [
+        {"source": "<blob checksum>", "offset": <n>, "size": <n>, "repeat": <n>},
+        ...
+    ]
+}
+
+To reconstruct the blob, process the pieces in order. For each piece,
+read "size" bytes starting at "offset" from the raw blob named by
+"source", and append them to the output. If the optional "repeat"
+value is present and greater than 1, append that same range of bytes
+that many times in a row. The sources of a recipe are always raw
+blobs; a recipe never refers to another recipe. When you have appended
+all pieces, the result is the original file, whose checksum will match
+the recipe name.
+
+When extracting a snapshot (see below), a bloblist entry may refer to
+a checksum that exists only as a recipe. In that case, reconstruct the
+data from the recipe instead of copying a raw blob.
+
+If a maximum blob size has been configured for this repository, the
+chosen value is recorded in the file "maxblobsize.txt" in the
+repository root.
+
 == The sessions==
 
 All data files are in the JSON file format. It is quite simple, but if
@@ -139,11 +190,15 @@ def integrity_assert(test, errormsg = None):
     if not test:
         raise CorruptionError(errormsg)
 
-def create_repository(repopath, enable_deduplication = False):
+def create_repository(repopath, enable_deduplication = False, max_blob_size = None):
     if enable_deduplication and not deduplication.dedup_available:
         # Ok, we COULD create a deduplicated repo without the module,
         # but the user is likely to be confused when he cannot use it.
         raise UserError("Cannot create deduplicated repository: deduplication module is not installed")
+    if max_blob_size is not None:
+        assert isinstance(max_blob_size, int)
+        if max_blob_size < MIN_MAX_BLOB_SIZE:
+            raise UserError("Maximum blob size must be at least %s bytes" % MIN_MAX_BLOB_SIZE)
     os.mkdir(repopath)
     create_file(os.path.join(repopath, VERSION_FILE), str(LATEST_REPO_FORMAT))
     for d in QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR, DERIVED_DIR, DERIVED_BLOCKS_DIR, RECIPES_DIR:
@@ -153,6 +208,8 @@ def create_repository(repopath, enable_deduplication = False):
     if enable_deduplication:
         with open(os.path.join(repopath, "ENABLE_DEDUPLICATION"), "wb"):
             pass
+    if max_blob_size is not None:
+        create_file(os.path.join(repopath, MAXBLOBSIZE_FILE), str(max_blob_size))
 
 def looks_like_repo(repo_path):
     """Superficial check to see if the given path contains anything
@@ -249,6 +306,27 @@ class Repo(object):
 
     def deduplication_enabled(self):
         return os.path.exists(os.path.join(self.repopath, "ENABLE_DEDUPLICATION"))
+
+    def get_max_blob_size(self):
+        """Returns the configured maximum raw blob size in bytes, or
+        None if blobs are unbounded (the default). Files larger than
+        this limit are split into several smaller blobs that are tied
+        together with a recipe, which makes it possible to store the
+        repository on filesystems with a maximum file size."""
+        if not hasattr(self, "_max_blob_size_cache"):
+            path = os.path.join(self.repopath, MAXBLOBSIZE_FILE)
+            if os.path.exists(path):
+                raw = bytes2str(read_file(path)).strip()
+                try:
+                    value = int(raw)
+                except ValueError:
+                    raise CorruptionError("Malformed maximum blob size configuration: %r" % raw)
+                integrity_assert(value >= MIN_MAX_BLOB_SIZE,
+                                 "Illegal maximum blob size configured: %s" % value)
+                self._max_blob_size_cache = value
+            else:
+                self._max_blob_size_cache = None
+        return self._max_blob_size_cache
 
     def __upgrade_repo(self):
         assert not self.readonly, "Repo is read only, cannot upgrade"
@@ -647,6 +725,7 @@ class Repo(object):
         result.append(('number_of_user_files', len(self.get_all_level_1_blobs())))
         result.append(('number_of_raw_blobs', len(self.get_raw_blob_names())))
         result.append(('number_of_recipes', len(self.get_recipe_names())))
+        result.append(('max_blob_size', self.get_max_blob_size()))
         virtual_size = sum([self.get_blob_size(md5) for md5 in self.get_all_level_1_blobs()])
         actual_size = sum([self.get_blob_size(md5) for md5 in self.get_raw_blob_names()])
         result.append(('virtual_size', virtual_size))

--- a/blobrepo/sessions.py
+++ b/blobrepo/sessions.py
@@ -183,25 +183,51 @@ class _NaiveSessionWriter(object):
 
 
 class PieceHandler(deduplication.OriginalPieceHandler):
-    """ A PieceHandler handles all the original data for a single
-    uploaded blob. A continous length of original data is called a
-    'piece'."""
-    def __init__(self, session_dir, block_size, tmpdir, BlockifierClass):
+    """ A PieceHandler handles all the original (non-deduplicated) data
+    for a single uploaded blob. A continous length of original data is
+    called a 'piece'.
+
+    The concatenation of all original data is referred to as the
+    "amalgam". By default the amalgam is stored as a single raw blob.
+    If the repository has a maximum blob size configured, the amalgam
+    is instead split into a sequence of "sub-blobs", each no larger
+    than that limit. Either way, the resulting recipe pieces always
+    refer to raw blobs that are within the size limit.
+
+    The actual size at which sub-blobs are cut (split_size) is rounded
+    down to a whole number of deduplication blocks. That way the cut
+    points line up with block boundaries, so the deduplication blocks
+    of a freshly stored file never straddle a sub-blob boundary and
+    remain available for deduplicating future files."""
+    def __init__(self, session_dir, block_size, tmpdir, BlockifierClass, max_blob_size = None):
         assert os.path.isdir(session_dir)
         assert block_size > 0
+        assert max_blob_size is None or max_blob_size >= block_size
         self.block_size = block_size
         self.session_dir = session_dir
+        self.max_blob_size = max_blob_size
+        if max_blob_size is None:
+            self.split_size = None
+        else:
+            # Round down to a whole number of blocks (at least one).
+            self.split_size = max(block_size, (max_blob_size // block_size) * block_size)
+            assert self.split_size <= max_blob_size
         self.blockifiers = {}
         self.blocks = None
         self.piece_start_offsets = {}
         self.current_index = None
         self.tmpdir = tmpdir
         self.BlockifierClass = BlockifierClass
-        self.filename = os.path.join(self.session_dir, "amalgam")
-        assert not os.path.exists(self.filename)
-        self.fileobj = open(self.filename, "wb")
-        self.md5summer = hashlib.md5()
-        self.offset = 0
+        self.closed = False
+
+        # The amalgam is physically stored as one or more sub-blobs.
+        self.sub_blobs = [] # list of (md5, size), in amalgam order
+        self.sub_blob_starts = None # filled in by close(): virtual start offset of each sub-blob
+        self.offset = 0 # total amount of original data seen so far (virtual amalgam size)
+        self._cur_file = None
+        self._cur_summer = None
+        self._cur_size = 0
+        self._cur_tmppath = None
 
     @overrides(deduplication.OriginalPieceHandler)
     def init_piece(self, index):
@@ -213,14 +239,58 @@ class PieceHandler(deduplication.OriginalPieceHandler):
         self.piece_start_offsets[index] = self.offset
         self.current_index = index
 
+    def __open_sub_blob(self):
+        assert self._cur_file == None
+        self._cur_tmppath = tempfile.mktemp(prefix = "amalgam_", dir = self.session_dir)
+        self._cur_file = open(self._cur_tmppath, "wb")
+        self._cur_summer = hashlib.md5()
+        self._cur_size = 0
+
+    def __finalize_sub_blob(self):
+        assert self._cur_file != None
+        self._cur_file.close()
+        self._cur_file = None
+        md5 = self._cur_summer.hexdigest()
+        real_name = os.path.join(self.session_dir, md5)
+        # An identical sub-blob may already have been written during
+        # this commit. If so, just drop our copy.
+        if os.path.exists(real_name):
+            # Necessary for windows. Posix silently replaces an existing file.
+            safe_delete_file(self._cur_tmppath)
+        else:
+            os.rename(self._cur_tmppath, real_name)
+        self.sub_blobs.append((md5, self._cur_size))
+        self._cur_tmppath = None
+        self._cur_summer = None
+        self._cur_size = 0
+
     @overrides(deduplication.OriginalPieceHandler)
     def add_piece_data(self, index, data):
         assert self.current_index == index
-        self.fileobj.write(data)
-        self.md5summer.update(data)
+        assert not self.closed
+        # The deduplication blockifier always sees the full data,
+        # independent of how it is physically split into sub-blobs.
         self.blockifiers[index].feed_string(data)
-        self.offset += len(data)
-        #print "Adding", len(data), "bytes"
+        view = memoryview(data)
+        pos = 0
+        total = len(data)
+        while pos < total:
+            if self._cur_file == None:
+                self.__open_sub_blob()
+            if self.split_size == None:
+                take = total - pos
+            else:
+                space = self.split_size - self._cur_size
+                assert space > 0
+                take = min(total - pos, space)
+            chunk = view[pos:pos + take]
+            self._cur_file.write(chunk)
+            self._cur_summer.update(chunk)
+            self._cur_size += take
+            self.offset += take
+            pos += take
+            if self.split_size != None and self._cur_size == self.split_size:
+                self.__finalize_sub_blob()
 
     @overrides(deduplication.OriginalPieceHandler)
     def end_piece(self, index):
@@ -231,29 +301,106 @@ class PieceHandler(deduplication.OriginalPieceHandler):
 
     @overrides(deduplication.OriginalPieceHandler)
     def close(self):
-        self.fileobj.close()
-        self.fileobj = None
-        self.final_md5 = self.md5summer.hexdigest()
-        real_name = os.path.join(self.session_dir, self.final_md5)
+        assert not self.closed
+        self.closed = True
+        # Finalize any partially-filled trailing sub-blob. If there was
+        # no original data at all, no sub-blob is created.
+        if self._cur_file != None:
+            self.__finalize_sub_blob()
 
-        # The piece may already have been added during this commit. If
-        # so, just ignore it.
-        if os.path.exists(real_name):
-            # Necessary for windows. Posix silently replaces an existing file.
-            safe_delete_file(self.filename)
-        else:
-            os.rename(self.filename, real_name)
+        if not self.sub_blobs and self.blockifiers:
+            # There was at least one original piece, but it carried no
+            # data at all (an empty file). Materialize a single empty
+            # sub-blob so that the zero-length piece can still be
+            # represented in the recipe, exactly as before.
+            self.__open_sub_blob()
+            self.__finalize_sub_blob()
 
+        # Compute the virtual start offset of each sub-blob.
+        self.sub_blob_starts = []
+        acc = 0
+        for md5, size in self.sub_blobs:
+            self.sub_blob_starts.append(acc)
+            acc += size
+        assert acc == self.offset, "Sub-blobs do not account for all original data"
+
+        # Harvest deduplication blocks, mapping each to the sub-blob
+        # that physically contains it. A block that straddles a
+        # sub-blob boundary cannot be addressed as a single (blob,
+        # offset) location, so it is simply dropped - it just won't be
+        # available for future deduplication.
         self.blocks = []
         for index, blockifier in list(self.blockifiers.items()):
+            piece_start = self.piece_start_offsets[index]
             for offset, rolling, md5 in blockifier.harvest():
-                self.blocks.append((self.final_md5, self.piece_start_offsets[index] + offset, rolling, md5))
+                location = self.__locate(piece_start + offset, self.block_size)
+                if location != None:
+                    sub_md5, offset_in_blob = location
+                    self.blocks.append((sub_md5, offset_in_blob, rolling, md5))
 
+    def __locate(self, virtual_offset, length):
+        """If the range [virtual_offset, virtual_offset+length) lies
+        entirely within a single sub-blob, return a (sub_blob_md5,
+        offset_within_sub_blob) tuple. Otherwise (the range straddles a
+        boundary or lies outside the amalgam) return None."""
+        assert self.closed
+        if self.split_size == None:
+            if not self.sub_blobs:
+                return None
+            md5, size = self.sub_blobs[0]
+            if virtual_offset + length <= size:
+                return md5, virtual_offset
+            return None
+        index = virtual_offset // self.split_size
+        if index != (virtual_offset + length - 1) // self.split_size:
+            return None # straddles a sub-blob boundary
+        if index >= len(self.sub_blobs):
+            return None
+        md5, size = self.sub_blobs[index]
+        offset_in_blob = virtual_offset - index * self.split_size
+        assert offset_in_blob + length <= size
+        return md5, offset_in_blob
 
     @overrides(deduplication.OriginalPieceHandler)
-    def get_piece_address(self, index):
-        assert self.fileobj == None
-        return self.final_md5, self.piece_start_offsets[index]
+    def get_piece_segments(self, index, size):
+        """Return a list of (sub_blob_md5, offset, size) segments that,
+        concatenated in order, reproduce the original piece's data. A
+        single piece may be spread over several sub-blobs when a
+        maximum blob size is configured."""
+        assert self.closed
+        return self.__map_range(self.piece_start_offsets[index], size)
+
+    def __map_range(self, virtual_offset, length):
+        segments = []
+        pos = virtual_offset
+        remaining = length
+        if length == 0:
+            # Zero-length piece (an empty file). Reference the sub-blob
+            # containing this position with a zero-length segment, so
+            # the recipe still contains a piece for it.
+            index = 0 if self.split_size == None else virtual_offset // self.split_size
+            if index < len(self.sub_blobs):
+                md5, size = self.sub_blobs[index]
+                sub_start = 0 if self.split_size == None else index * self.split_size
+                segments.append((md5, virtual_offset - sub_start, 0))
+            return segments
+        while remaining > 0:
+            if self.split_size == None:
+                index = 0
+                sub_start = 0
+            else:
+                index = pos // self.split_size
+                sub_start = index * self.split_size
+            assert index < len(self.sub_blobs), \
+                "Original data range exceeds the stored sub-blobs"
+            md5, size = self.sub_blobs[index]
+            offset_in_blob = pos - sub_start
+            segment_size = min(remaining, size - offset_in_blob)
+            assert segment_size > 0
+            segments.append((md5, offset_in_blob, segment_size))
+            pos += segment_size
+            remaining -= segment_size
+        return segments
 
 class SessionWriter(object):
     def __init__(self, repo, session_name, base_session = None, session_id = None, force_base_snapshot = False):
@@ -266,7 +413,7 @@ class SessionWriter(object):
         self.repo = repo
         self.tmpblocksdb = deduplication.TmpBlocksDB(self.repo.blocksdb)
         self.session_name = session_name
-        self.max_blob_size = None
+        self.max_blob_size = repo.get_max_blob_size()
         self.base_session = base_session
         self.force_base_snapshot = force_base_snapshot
         self.metadatas = {}
@@ -340,7 +487,8 @@ class SessionWriter(object):
                                        blobsource,
                                        PieceHandler(self.session_path, repository.DEDUP_BLOCK_SIZE,
                                                     tmpdir = self.repo.get_tmpdir(),
-                                                    BlockifierClass = blockifierclass),
+                                                    BlockifierClass = blockifierclass,
+                                                    max_blob_size = self.max_blob_size),
                                        tmpdir = self.repo.get_tmpdir(),
                                        RollingChecksumClass = rollingchecksumclass)
 

--- a/boar
+++ b/boar
@@ -433,16 +433,28 @@ def cmd_info(args):
 def cmd_mkrepo(args):
     if len(args) == 0:
         args = ["--help"]
-    parser = OptionParser(usage="usage: boar mkrepo [-d|--enable-deduplication] <new repo path>")
+    parser = OptionParser(usage="usage: boar mkrepo [-d|--enable-deduplication] [-m|--max-file-size SIZE] <new repo path>")
     parser.add_option("-d", "--enable-deduplication", dest = "dedup", action="store_true",
                       help="Enable deduplication for this repository")
+    parser.add_option("-m", "--max-file-size", dest = "max_file_size", metavar="SIZE",
+                      help="Store files larger than SIZE by splitting them into smaller "
+                      "blobs tied together with a recipe. This makes it possible to keep "
+                      "the repository on a filesystem with a maximum file size. SIZE may "
+                      "use the suffixes k, M, G or T (powers of 1024), for example '2G'.")
     (options, args) = parser.parse_args(args)
     if len(args) > 1:
         raise UserError("Too many arguments")
     repopath, = args
     if os.path.exists(repopath):
         raise UserError("File or directory already exists: %s" % repopath)
-    repository.create_repository(repopath, enable_deduplication = options.dedup)
+    max_blob_size = None
+    if options.max_file_size is not None:
+        try:
+            max_blob_size = parse_human_size(options.max_file_size)
+        except ValueError as e:
+            raise UserError("Invalid --max-file-size value: %s" % e)
+    repository.create_repository(repopath, enable_deduplication = options.dedup,
+                                 max_blob_size = max_blob_size)
 
 def cmd_list(args):
     parser = OptionParser(usage="usage: boar list [session name [snapshot id]]")

--- a/common.py
+++ b/common.py
@@ -22,6 +22,7 @@ import platform
 import locale
 import codecs
 import errno
+import math
 import time
 import textwrap
 import stat as statmod
@@ -178,6 +179,40 @@ def read_md5sum(path, expected_md5 = None):
     non-utf-8 files is md5sum.exe on Windows."""
     data = read_file(path, expected_md5).decode("utf-8-sig")
     return parse_md5sum(data)
+
+def parse_human_size(s):
+    """Parse a human-friendly size string into a number of bytes.
+
+    Accepts a plain integer ("65536") or a number followed by one of
+    the binary suffixes k, M, G or T (powers of 1024,
+    case-insensitive). An optional trailing 'b'/'B' is allowed, so
+    "5M", "5MB", "5mb" and "5242880" all mean the same thing. Decimal
+    values such as "1.5G" are accepted. Raises ValueError on malformed
+    input or negative values."""
+    assert isinstance(s, str)
+    text = s.strip().lower()
+    if not text:
+        raise ValueError("Empty size string")
+    if text.endswith("b"):
+        # Allow an explicit byte marker, e.g. "100b" or "5mb".
+        text = text[:-1]
+    units = {'k': 1024, 'm': 1024 ** 2, 'g': 1024 ** 3, 't': 1024 ** 4}
+    multiplier = 1
+    if text and text[-1] in units:
+        multiplier = units[text[-1]]
+        text = text[:-1]
+    text = text.strip()
+    if not text:
+        raise ValueError("Malformed size: %r" % s)
+    try:
+        value = float(text)
+    except ValueError:
+        raise ValueError("Malformed size: %r" % s)
+    if not math.isfinite(value):
+        raise ValueError("Malformed size: %r" % s)
+    if value < 0:
+        raise ValueError("Size must not be negative: %r" % s)
+    return int(value * multiplier)
 
 _file_reader_sum = 0
 def file_reader(f, start = 0, end = None, blocksize = 2 ** 16):

--- a/deduplication.py
+++ b/deduplication.py
@@ -216,6 +216,16 @@ class OriginalPieceHandler(object):
         recipe."""
         pass
 
+    def get_piece_segments(self, index, size):
+        """After the handler has been closed, this method must return a
+        list of (blob, offset, size) segments that, concatenated in
+        order, reproduce the data of the given piece. The default
+        implementation stores each piece in a single blob and so
+        returns a single segment; handlers that split data across
+        several blobs override this."""
+        blob, offset = self.get_piece_address(index)
+        return [(blob, offset, size)]
+
 from statemachine import GenericStateMachine
 
 START_STATE = "START"
@@ -433,10 +443,15 @@ class RecipeFinder(GenericStateMachine):
 
         for s in self.sequences:
             if isinstance(s, Struct):
-                # Original data
-                restored_size += s.piece_size
-                blob, offset = s.piece_handler.get_piece_address(s.piece_index)
-                yield get_dict(blob, offset, s.piece_size, True)
+                # Original data. The piece may be spread over several
+                # blobs if a maximum blob size is configured, so emit
+                # one recipe piece per stored segment.
+                segment_total = 0
+                for blob, offset, segment_size in s.piece_handler.get_piece_segments(s.piece_index, s.piece_size):
+                    segment_total += segment_size
+                    restored_size += segment_size
+                    yield get_dict(blob, offset, segment_size, True)
+                assert segment_total == s.piece_size
 
             elif type(s) == list:
                 # Duplicated data

--- a/front.py
+++ b/front.py
@@ -589,7 +589,9 @@ class Front(object):
 
     def new_snapshot_has_blob(self, sum):
         assert self.new_session, "new_snapshot_has_blob() must only be called when a new snapshot is underway"
-        return self.new_session.has_blob(sum)
+        # A blob already uploaded in this snapshot may be stored either
+        # as a raw blob or, for oversized/deduplicated files, as a recipe.
+        return self.new_session.has_blob(sum) or self.new_session.has_recipe(sum)
 
     def find_last_revision(self, session_name):
         """ Returns the id of the latest snapshot in the specified
@@ -633,6 +635,9 @@ class Front(object):
 
     def deduplication_enabled(self):
         return self.repo.deduplication_enabled()
+
+    def get_max_blob_size(self):
+        return self.repo.get_max_blob_size()
 
 class DryRunFront(object):
 

--- a/macrotests/test_maxblobsize.sh
+++ b/macrotests/test_maxblobsize.sh
@@ -1,0 +1,137 @@
+# Tests for the "maximum blob size" feature: files larger than the
+# configured limit are split into several smaller blobs tied together
+# with a recipe, so that the repository can live on a filesystem with a
+# maximum file size.
+
+TESTDIR="`pwd`"
+REPO=$TESTDIR/repo
+BIGFILE=$TESTDIR/bigfile.bin
+
+MAX=102400 # 100 KiB, the limit used for $REPO
+
+# A deterministic ~1 MB file (same one used by test_recipes.sh).
+python3 "${BOARTESTHOME}/mkrandfile.py" 0 1000000 $BIGFILE || exit 1
+md5sum -c <<EOF || exit 1
+d978f6138c52b8be4f07bbbf571cd450  $BIGFILE
+EOF
+BIGMD5=d978f6138c52b8be4f07bbbf571cd450
+
+assert_no_blob_over () {
+    # assert_no_blob_over <repo> <limit-in-bytes>
+    local repo="$1"; local limit="$2"
+    local toobig
+    toobig=`find "$repo/blobs" -type f -size +${limit}c`
+    if [ -n "$toobig" ]; then
+        echo "*** FAIL: found blob(s) larger than $limit bytes in $repo:"
+        find "$repo/blobs" -type f -size +${limit}c -printf '%s %p\n'
+        exit 1
+    fi
+}
+
+############################################################
+echo "*** Splitting without deduplication"
+
+$BOAR mkrepo --max-file-size 100k $REPO || exit 1
+test "`cat $REPO/maxblobsize.txt`" = "102400" || { echo "Wrong maxblobsize.txt contents"; exit 1; }
+
+$BOAR --repo=$REPO mksession Big || exit 1
+$BOAR --repo=$REPO co Big || exit 1
+(cd Big &&
+    cp $BIGFILE bigfile.bin &&
+    md5sum bigfile.bin >manifest.md5 &&
+    $BOAR ci -q ) || exit 1
+
+assert_no_blob_over $REPO $MAX
+# The oversized file must be stored as a recipe, not a raw blob.
+test -e $REPO/recipes/d9/$BIGMD5.recipe || { echo "Expected recipe is missing"; exit 1; }
+test ! -e $REPO/blobs/d9/$BIGMD5 || { echo "Oversized file should not be a raw blob"; exit 1; }
+
+$BOAR --repo=$REPO verify || { echo "Verify failed"; exit 1; }
+rm -r Big || exit 1
+$BOAR --repo=$REPO co Big || { echo "Check-out failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big || exit 1
+
+############################################################
+echo "*** A small file stays a single raw blob"
+
+(cd /tmp && true) # no-op to keep structure clear
+$BOAR --repo=$REPO co Big || exit 1
+(cd Big &&
+    head -c 1000 $BIGFILE >small.bin &&
+    SMALLMD5=`md5sum small.bin | cut -d' ' -f1` &&
+    md5sum bigfile.bin small.bin >manifest.md5 &&
+    $BOAR ci -q &&
+    test -e $REPO/blobs/${SMALLMD5:0:2}/$SMALLMD5 || { echo "Small file should be a raw blob"; exit 1; }
+    test ! -e $REPO/recipes/${SMALLMD5:0:2}/$SMALLMD5.recipe || { echo "Small file should not have a recipe"; exit 1; }
+) || exit 1
+assert_no_blob_over $REPO $MAX
+$BOAR --repo=$REPO verify || { echo "Verify failed"; exit 1; }
+rm -r Big || exit 1
+
+############################################################
+echo "*** Cloning a split repo into a plain repo reassembles the file"
+
+CLONE_PLAIN=$TESTDIR/clone_plain
+$BOAR clone $REPO $CLONE_PLAIN || { echo "Clone failed"; exit 1; }
+test ! -e $CLONE_PLAIN/maxblobsize.txt || { echo "Plain clone unexpectedly has a max blob size"; exit 1; }
+# Without a limit, the big file is stored as a single raw blob.
+test -e $CLONE_PLAIN/blobs/d9/$BIGMD5 || { echo "Expected reassembled raw blob in plain clone"; exit 1; }
+test ! -e $CLONE_PLAIN/recipes/d9/$BIGMD5.recipe || { echo "Plain clone should not have a recipe"; exit 1; }
+$BOAR --repo=$CLONE_PLAIN verify || { echo "Plain clone verify failed"; exit 1; }
+$BOAR --repo=$CLONE_PLAIN co Big || { echo "Plain clone checkout failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big || exit 1
+
+############################################################
+echo "*** Cloning into a repo with a (different) limit re-splits the file"
+
+CLONE_SPLIT=$TESTDIR/clone_split
+$BOAR mkrepo --max-file-size 70k $CLONE_SPLIT || exit 1
+$BOAR clone $REPO $CLONE_SPLIT || { echo "Clone (split) failed"; exit 1; }
+assert_no_blob_over $CLONE_SPLIT 71680
+test -e $CLONE_SPLIT/recipes/d9/$BIGMD5.recipe || { echo "Re-split clone is missing the recipe"; exit 1; }
+$BOAR --repo=$CLONE_SPLIT verify || { echo "Re-split clone verify failed"; exit 1; }
+$BOAR --repo=$CLONE_SPLIT co Big || { echo "Re-split clone checkout failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big $CLONE_PLAIN $CLONE_SPLIT $REPO || exit 1
+
+############################################################
+if [ "$BOAR_SKIP_DEDUP_TESTS" == "1" ]; then
+    echo "Skipping deduplication part due to BOAR_SKIP_DEDUP_TESTS"
+    exit 0
+fi
+
+echo "*** Splitting combined with deduplication"
+
+$BOAR mkrepo --enable-deduplication --max-file-size 100k $REPO || exit 1
+$BOAR --repo=$REPO mksession Dedup || exit 1
+$BOAR --repo=$REPO co Dedup || exit 1
+(cd Dedup &&
+    cp $BIGFILE a.bin &&
+    $BOAR ci -q ) || exit 1
+raw_after_first=`find $REPO/blobs -type f | wc -l`
+
+(cd Dedup &&
+    ( echo "a unique short prefix"; cat $BIGFILE ) >b.bin &&
+    md5sum a.bin b.bin >manifest.md5 &&
+    $BOAR ci -q ) || exit 1
+raw_after_second=`find $REPO/blobs -type f | wc -l`
+
+assert_no_blob_over $REPO $MAX
+# Deduplication should keep the number of new raw blobs small, even
+# though the shared body is stored split across several sub-blobs.
+new_blobs=$((raw_after_second - raw_after_first))
+echo "New raw blobs from the near-identical second file: $new_blobs"
+if [ "$new_blobs" -gt 3 ]; then
+    echo "*** FAIL: deduplication across split boundaries did not work ($new_blobs new blobs)"
+    exit 1
+fi
+
+$BOAR --repo=$REPO verify || { echo "Dedup verify failed"; exit 1; }
+rm -r Dedup || exit 1
+$BOAR --repo=$REPO co Dedup || { echo "Dedup checkout failed"; exit 1; }
+(cd Dedup && md5sum -c manifest.md5 ) || exit 1
+rm -r Dedup $REPO || exit 1
+
+exit 0

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -48,6 +48,7 @@ class FakePieceHandler(object):
     def end_piece(self, index): pass
     def close(self): pass
     def get_piece_address(self, index): return ("FAKEBLOB", 0)
+    def get_piece_segments(self, index, size): return [("FAKEBLOB", 0, size)]
 
 
 class TestRecipeFinder(unittest.TestCase, WorkdirHelper):

--- a/tests/test_maxblobsize.py
+++ b/tests/test_maxblobsize.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2010 Mats Ekberg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the per-repository maximum blob size feature, which
+splits oversized files into several smaller blobs tied together with a
+recipe."""
+
+import sys, os, unittest
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import workdir
+from blobrepo import repository
+from common import md5sum, DevNull, parse_human_size
+from boar_exceptions import UserError
+from front import Front, verify_repo
+from deduplication import dedup_available
+from wdtools import WorkdirHelper
+
+
+def deterministic_bytes(n, seed=0):
+    """Return n bytes of deterministic, hard-to-compress data."""
+    return bytes(((i * 2654435761 + seed * 40503 + 7) % 251) for i in range(n))
+
+
+class TestParseHumanSize(unittest.TestCase):
+    def testPlainInteger(self):
+        self.assertEqual(parse_human_size("0"), 0)
+        self.assertEqual(parse_human_size("65536"), 65536)
+        self.assertEqual(parse_human_size(" 100 "), 100)
+
+    def testSuffixes(self):
+        self.assertEqual(parse_human_size("1k"), 1024)
+        self.assertEqual(parse_human_size("1K"), 1024)
+        self.assertEqual(parse_human_size("2M"), 2 * 1024 ** 2)
+        self.assertEqual(parse_human_size("3g"), 3 * 1024 ** 3)
+        self.assertEqual(parse_human_size("1T"), 1024 ** 4)
+
+    def testByteMarker(self):
+        self.assertEqual(parse_human_size("100b"), 100)
+        self.assertEqual(parse_human_size("5MB"), 5 * 1024 ** 2)
+        self.assertEqual(parse_human_size("5mb"), 5 * 1024 ** 2)
+
+    def testFractional(self):
+        self.assertEqual(parse_human_size("1.5k"), 1536)
+
+    def testMalformed(self):
+        for bad in ("", "   ", "abc", "1.2.3", "k", "M", "-5", "-1k", "5x",
+                    "inf", "infinity", "infg", "nan", "9" * 400):
+            self.assertRaises(ValueError, parse_human_size, bad)
+
+
+class TestRepoConfig(unittest.TestCase, WorkdirHelper):
+    def setUp(self):
+        self.remove_at_teardown = []
+
+    def tearDown(self):
+        import shutil
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def testDefaultIsNone(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath)
+        repo = repository.Repo(repopath)
+        self.assertEqual(repo.get_max_blob_size(), None)
+
+    def testStoredAndRead(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath, max_blob_size=131072)
+        self.assertTrue(os.path.exists(os.path.join(repopath, repository.MAXBLOBSIZE_FILE)))
+        repo = repository.Repo(repopath)
+        self.assertEqual(repo.get_max_blob_size(), 131072)
+        # Make sure it is reported in the repo statistics too.
+        stats = dict(repo.get_stats())
+        self.assertEqual(stats["max_blob_size"], 131072)
+
+    def testBelowMinimumRejected(self):
+        repopath = self.createTmpName()
+        self.assertRaises(UserError, repository.create_repository,
+                          repopath, max_blob_size=repository.MIN_MAX_BLOB_SIZE - 1)
+        self.assertFalse(os.path.exists(repopath))
+
+    def testCorruptConfigRaisesCorruptionError(self):
+        from boar_exceptions import CorruptionError
+        repopath = self.createTmpName()
+        repository.create_repository(repopath, max_blob_size=131072)
+        with open(os.path.join(repopath, repository.MAXBLOBSIZE_FILE), "wb") as f:
+            f.write(b"not-a-number")
+        repo = repository.Repo(repopath)
+        self.assertRaises(CorruptionError, repo.get_max_blob_size)
+
+
+class _SplitTestBase(unittest.TestCase, WorkdirHelper):
+    enable_deduplication = False
+
+    def setUp(self):
+        self.remove_at_teardown = []
+        self.workdir = self.createTmpName()
+        self.repopath = self.createTmpName()
+        self.max_blob_size = 65536
+        repository.create_repository(self.repopath,
+                                     enable_deduplication=self.enable_deduplication,
+                                     max_blob_size=self.max_blob_size)
+        os.mkdir(self.workdir)
+        self.wd = workdir.Workdir(self.repopath, u"TestSession", u"", None, self.workdir)
+        self.wd.setLogOutput(DevNull())
+        self.wd.use_progress_printer(False)
+        self.repo = self.wd.front.repo
+        self.wd.get_front().mksession(u"TestSession")
+
+    def tearDown(self):
+        import shutil
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def assert_blob_size_invariant(self):
+        """No raw blob in the repository may exceed the configured limit."""
+        for name in self.repo.get_raw_blob_names():
+            size = os.path.getsize(self.repo.get_blob_path(name))
+            self.assertTrue(size <= self.max_blob_size,
+                            "Raw blob %s has size %s > limit %s" % (name, size, self.max_blob_size))
+
+    def assert_roundtrip(self, md5, expected_content):
+        reader = self.wd.front.get_blob(md5)
+        data = reader.read()
+        self.assertEqual(len(data), len(expected_content))
+        self.assertEqual(md5sum(data), md5)
+        self.assertEqual(data, expected_content)
+
+
+class TestSplitNoDedup(_SplitTestBase):
+    enable_deduplication = False
+
+    def testFileLargerThanLimitGetsRecipe(self):
+        content = deterministic_bytes(350000, seed=1)  # not a multiple of the limit
+        md5 = self.addWorkdirFile("big.bin", content)
+        self.wd.checkin()
+        # The file must be represented by a recipe, not a single raw blob.
+        self.assertTrue(self.repo.has_recipe_blob(md5))
+        self.assertFalse(self.repo.has_raw_blob(md5))
+        recipe = self.repo.get_recipe(md5)
+        self.assertEqual(recipe["size"], len(content))
+        self.assertEqual(sum(p["size"] * p["repeat"] for p in recipe["pieces"]), len(content))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5, content)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+    def testFileAtAndBelowLimitStaysRaw(self):
+        exact = deterministic_bytes(self.max_blob_size, seed=2)
+        small = deterministic_bytes(1000, seed=3)
+        md5_exact = self.addWorkdirFile("exact.bin", exact)
+        md5_small = self.addWorkdirFile("small.bin", small)
+        self.wd.checkin()
+        for md5 in (md5_exact, md5_small):
+            self.assertTrue(self.repo.has_raw_blob(md5))
+            self.assertFalse(self.repo.has_recipe_blob(md5))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5_exact, exact)
+        self.assert_roundtrip(md5_small, small)
+
+    def testEmptyFile(self):
+        md5 = self.addWorkdirFile("empty.bin", b"")
+        self.wd.checkin()
+        self.assertEqual(md5, "d41d8cd98f00b204e9800998ecf8427e")
+        self.assertTrue(self.repo.has_raw_blob(md5))
+        self.assertFalse(self.repo.has_recipe_blob(md5))
+        self.assert_roundtrip(md5, b"")
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+    def testIdenticalLargeFilesShareSubBlobs(self):
+        content = deterministic_bytes(200000, seed=4)
+        self.addWorkdirFile("a.bin", content)
+        self.addWorkdirFile("b.bin", content)
+        self.wd.checkin()
+        # Two identical files share the same recipe and the same set of
+        # sub-blobs, so the raw blob count is exactly the number of
+        # chunks of a single file.
+        expected_chunks = (len(content) + self.max_blob_size - 1) // self.max_blob_size
+        self.assertEqual(len(self.repo.get_raw_blob_names()), expected_chunks)
+        self.assertEqual(len(self.repo.get_recipe_names()), 1)
+        self.assert_blob_size_invariant()
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+@unittest.skipUnless(dedup_available, "deduplication module not installed")
+class TestSplitWithDedup(_SplitTestBase):
+    enable_deduplication = True
+
+    def testDedupAcrossSplitBoundaries(self):
+        base = deterministic_bytes(300000, seed=5)
+        md5_a = self.addWorkdirFile("a.bin", base)
+        self.wd.checkin()
+        raw_after_first = len(self.repo.get_raw_blob_names())
+
+        # A second file that contains the same large body with a small
+        # prefix. Block deduplication should recognise the shared body
+        # even though it is stored split across several sub-blobs, so
+        # only a small amount of new raw data is added.
+        b_content = b"A short unique prefix.\n" + base
+        md5_b = self.addWorkdirFile("b.bin", b_content)
+        self.wd.checkin()
+        raw_after_second = len(self.repo.get_raw_blob_names())
+
+        self.assertTrue(self.repo.has_recipe_blob(md5_b))
+        recipe_b = self.repo.get_recipe(md5_b)
+        self.assertTrue(any(not p["original"] for p in recipe_b["pieces"]),
+                        "Expected deduplicated (non-original) pieces in the recipe")
+        # Far fewer new blobs than a naive re-split would require.
+        self.assertTrue(raw_after_second - raw_after_first <= 2,
+                        "Too many new raw blobs: %s -> %s" % (raw_after_first, raw_after_second))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5_a, base)
+        self.assert_roundtrip(md5_b, b_content)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
"boar mkrepo --max-file-size SIZE" records a maximum blob size for the
repository. Any committed file larger than the limit is stored as several
size-bounded raw sub-blobs tied together with a concat recipe, so the repo
can live on a filesystem with a small maximum file size (e.g. FAT32).

The split happens entirely in the server-side commit write path and reuses
the existing recipe machinery, so the RPC, clone, workdir and on-disk repo
formats are unchanged. Sub-blob cut points are aligned down to a whole
number of deduplication blocks, so block-level deduplication keeps working
across the split. With no limit configured, the behaviour is byte-identical
to before.

Tested by `tests/test_maxblobsize.py` and `macrotests/test_maxblobsize.sh`
(local and simulated-remote modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
