### PR TITLE
Add per-repository blob compression via a new recipe type

### DIFF
--- a/blobrepo/blobreader.py
+++ b/blobrepo/blobreader.py
@@ -1,8 +1,13 @@
 from common import *
 from jsonrpc import DataSource
 import deduplication
+import compression
 import boar_exceptions
 from copy import copy
+
+# Size of the chunks used when streaming compressed data to/from a
+# decompressor. Just a reasonable value, not part of any format.
+DECOMP_CHUNK_SIZE = 2 ** 16
 
 """ A recipe has the following format:
 
@@ -21,11 +26,26 @@ from copy import copy
     ]
 }
 
+A "compress" recipe has the same shape but an additional "algorithm"
+field. Its pieces, concatenated, form the compressed data; decompressing
+that data with the named algorithm yields the original blob. "size" is
+the size of the decompressed (original) data.
 """
+
+def create_recipe_reader(recipe, repo, offset = 0, size = None, local_path = None):
+    """Return a streaming reader for the given recipe, dispatching on its
+    'method'. This is the entry point that understands every recipe type."""
+    assert recipe
+    method = recipe.get('method')
+    if method == "concat":
+        return RecipeReader(recipe, repo, offset = offset, size = size, local_path = local_path)
+    if method == "compress":
+        return CompressReader(recipe, repo, offset = offset, size = size, local_path = local_path)
+    raise boar_exceptions.CorruptionError("Unknown recipe method: %r" % (method,))
 
 def create_blob_reader(recipe, repo):
     assert recipe
-    return RecipeReader(recipe, repo)
+    return create_recipe_reader(recipe, repo)
 
 class RecipeReader(DataSource):
     def __init__(self, recipe, repo, offset = 0, size = None, local_path = None):
@@ -132,10 +152,130 @@ class RecipeReader(DataSource):
             self.current_piece_index = self.__search_forward(current_recipe_read_position, start_index = self.current_piece_index)
             remaining = readsize - len(result)
             data = self.__read_piece_data(self.pieces[self.current_piece_index], current_recipe_read_position, remaining)
+            if not data:
+                # The source blob is shorter than the recipe claims (a
+                # truncated/corrupt blob on disk). Without this guard the
+                # loop would spin forever making no progress.
+                raise boar_exceptions.CorruptionError(
+                    "Blob %s is truncated: a recipe expected more data than is present on disk"
+                    % self.pieces[self.current_piece_index]['source'])
             result += data
             self.bytes_left_in_segment -= len(data)
         self.progress_callback(calculate_progress(self.segment_size, self.segment_size - self.bytes_left_in_segment))
         return result
+
+    def set_progress_callback(self, progress_callback):
+        assert callable(progress_callback)
+        self.progress_callback = progress_callback
+
+
+class CompressReader(DataSource):
+    """Streaming reader for a "compress" recipe. It reads the compressed
+    data by concatenating the recipe's pieces (reusing RecipeReader) and
+    decompresses it on the fly with the algorithm named in the recipe,
+    so the original blob never has to be materialised in full."""
+
+    def __init__(self, recipe, repo, offset = 0, size = None, local_path = None):
+        assert recipe['method'] == "compress"
+        assert 'md5sum' in recipe and is_md5sum(recipe['md5sum'])
+        assert 'algorithm' in recipe
+        assert 'size' in recipe and recipe['size'] >= 0
+        assert offset >= 0
+        assert size == None or size >= 0
+        self.md5sum = recipe['md5sum']
+        self.total_size = recipe['size']
+        if size == None:
+            size = self.total_size - offset
+        assert offset + size <= self.total_size
+        self.segment_size = size
+        self.bytes_left_in_segment = size
+        self.progress_callback = lambda x: None
+
+        self.decompressor = compression.get_codec(recipe['algorithm']).decompressor()
+
+        # The compressed data is itself just a concatenation of raw
+        # blobs, so reuse a RecipeReader to stream it.
+        pieces = recipe['pieces']
+        compressed_size = sum(piece['size'] * piece.get('repeat', 1) for piece in pieces)
+        compressed_recipe = {"method": "concat",
+                             "md5sum": "0" * 32, # not verified, just needs to be well-formed
+                             "size": compressed_size,
+                             "pieces": pieces}
+        self.compressed = RecipeReader(compressed_recipe, repo, offset = 0,
+                                       size = compressed_size, local_path = local_path)
+
+        self.buffer = bytearray()
+        self.buffer_pos = 0
+        if offset:
+            self.__skip(offset)
+
+    @overrides(DataSource)
+    def bytes_left(self):
+        return self.bytes_left_in_segment
+
+    def __pump(self):
+        """Decompress a little more into the buffer. Returns False only
+        when no further progress is possible (end of stream, or the
+        compressed input is exhausted while more is still required).
+
+        Note: some decompressors (notably lz4's frame decompressor) report
+        needs_input == False right after a length-limited read, but then
+        return zero bytes on the following drain call before flipping
+        needs_input back to True. A zero-byte step is therefore not treated
+        as a stall as long as the codec still has, or has just asked for,
+        input."""
+        if self.decompressor.eof:
+            return False
+        if self.decompressor.needs_input:
+            if self.compressed.bytes_left() == 0:
+                return False
+            feed = self.compressed.read(min(self.compressed.bytes_left(), DECOMP_CHUNK_SIZE))
+        else:
+            feed = b""
+        produced = self.decompressor.decompress(feed, DECOMP_CHUNK_SIZE)
+        if produced:
+            self.buffer += produced
+            return True
+        # No output this step. If we supplied no input and the codec still
+        # does not want any, the stream is genuinely stuck.
+        if not feed and not self.decompressor.needs_input:
+            return False
+        return True
+
+    def __emit(self, count):
+        """Produce and consume up to `count` decompressed bytes."""
+        while (len(self.buffer) - self.buffer_pos) < count:
+            if not self.__pump():
+                break
+        out = bytes(self.buffer[self.buffer_pos : self.buffer_pos + count])
+        self.buffer_pos += len(out)
+        if self.buffer_pos > 2 ** 20:
+            del self.buffer[:self.buffer_pos]
+            self.buffer_pos = 0
+        return out
+
+    def __skip(self, n):
+        while n > 0:
+            got = self.__emit(min(n, DECOMP_CHUNK_SIZE))
+            if not got:
+                raise boar_exceptions.CorruptionError(
+                    "Compressed blob %s is truncated or corrupt" % self.md5sum)
+            n -= len(got)
+
+    @overrides(DataSource)
+    def read(self, readsize = None):
+        if readsize == None:
+            readsize = self.bytes_left_in_segment
+        readsize = min(readsize, self.bytes_left_in_segment)
+        assert readsize >= 0
+        out = self.__emit(readsize)
+        if len(out) < readsize:
+            raise boar_exceptions.CorruptionError(
+                "Compressed blob %s is truncated or corrupt" % self.md5sum)
+        self.bytes_left_in_segment -= len(out)
+        self.progress_callback(calculate_progress(self.segment_size,
+                                                  self.segment_size - self.bytes_left_in_segment))
+        return out
 
     def set_progress_callback(self, progress_callback):
         assert callable(progress_callback)

--- a/blobrepo/repository.py
+++ b/blobrepo/repository.py
@@ -35,6 +35,7 @@ from boar_exceptions import *
 from .blobreader import create_blob_reader
 
 import deduplication
+import compression
 
 LATEST_REPO_FORMAT = 5
 REPOID_FILE = "repoid.txt"
@@ -51,6 +52,7 @@ DERIVED_BLOCKS_DIR = os.path.join(DERIVED_DIR, "blocks")
 DERIVED_BLOCKS_DB = os.path.join(DERIVED_BLOCKS_DIR, "blocks.db")
 DELETE_MARKER = "deleted.json"
 MAXBLOBSIZE_FILE = "maxblobsize.txt"
+COMPRESSION_FILE = "compression.txt"
 
 # The smallest maximum blob size that may be configured for a
 # repository. It must be at least one deduplication block so that the
@@ -138,6 +140,17 @@ blobs; a recipe never refers to another recipe. When you have appended
 all pieces, the result is the original file, whose checksum will match
 the recipe name.
 
+A recipe may instead have the method "compress". In that case the blob
+data is stored compressed, and the recipe additionally contains an
+"algorithm" field (such as "gzip", "xz", "bz2" or "lz4"). To
+reconstruct such a blob, first concatenate the pieces exactly as
+described above - this yields the compressed data in that algorithm's
+standard container format (for example, a "gzip" source can be
+expanded with the standard "gunzip" tool). Then decompress that data
+with the named algorithm to obtain the original file, whose checksum
+will again match the recipe name. The "size" field is the size of the
+decompressed (original) data.
+
 When extracting a snapshot (see below), a bloblist entry may refer to
 a checksum that exists only as a recipe. In that case, reconstruct the
 data from the recipe instead of copying a raw blob.
@@ -190,7 +203,7 @@ def integrity_assert(test, errormsg = None):
     if not test:
         raise CorruptionError(errormsg)
 
-def create_repository(repopath, enable_deduplication = False, max_blob_size = None):
+def create_repository(repopath, enable_deduplication = False, max_blob_size = None, compression_algorithm = None):
     if enable_deduplication and not deduplication.dedup_available:
         # Ok, we COULD create a deduplicated repo without the module,
         # but the user is likely to be confused when he cannot use it.
@@ -199,6 +212,11 @@ def create_repository(repopath, enable_deduplication = False, max_blob_size = No
         assert isinstance(max_blob_size, int)
         if max_blob_size < MIN_MAX_BLOB_SIZE:
             raise UserError("Maximum blob size must be at least %s bytes" % MIN_MAX_BLOB_SIZE)
+    if compression_algorithm is not None:
+        # get_codec() raises a UserError if the algorithm is unknown or
+        # its module is not installed (the user could not read the repo).
+        compression.get_codec(compression_algorithm)
+        compression_algorithm = compression.canonical_name(compression_algorithm)
     os.mkdir(repopath)
     create_file(os.path.join(repopath, VERSION_FILE), str(LATEST_REPO_FORMAT))
     for d in QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR, DERIVED_DIR, DERIVED_BLOCKS_DIR, RECIPES_DIR:
@@ -210,6 +228,8 @@ def create_repository(repopath, enable_deduplication = False, max_blob_size = No
             pass
     if max_blob_size is not None:
         create_file(os.path.join(repopath, MAXBLOBSIZE_FILE), str(max_blob_size))
+    if compression_algorithm is not None:
+        create_file(os.path.join(repopath, COMPRESSION_FILE), compression_algorithm)
 
 def looks_like_repo(repo_path):
     """Superficial check to see if the given path contains anything
@@ -263,6 +283,12 @@ class Repo(object):
         if self.deduplication_enabled() and not deduplication.dedup_available:
             self.readonly = True
             notice("This repository requires the native deduplication module for writing - only read operations can be performed.")
+
+        configured_compression = self.get_compression()
+        if configured_compression and not compression.is_available(configured_compression):
+            self.readonly = True
+            notice("This repository stores its data compressed with '%s', which is not available here - "
+                   "writing is disabled and reading compressed blobs will fail." % configured_compression)
 
         if not self.readonly:
             self.repo_mutex.lock_with_timeout(60)
@@ -327,6 +353,18 @@ class Repo(object):
             else:
                 self._max_blob_size_cache = None
         return self._max_blob_size_cache
+
+    def get_compression(self):
+        """Returns the canonical name of the compression algorithm that
+        this repository stores its blob data with, or None if blobs are
+        stored uncompressed (the default)."""
+        if not hasattr(self, "_compression_cache"):
+            path = os.path.join(self.repopath, COMPRESSION_FILE)
+            if os.path.exists(path):
+                self._compression_cache = compression.canonical_name(bytes2str(read_file(path)).strip())
+            else:
+                self._compression_cache = None
+        return self._compression_cache
 
     def __upgrade_repo(self):
         assert not self.readonly, "Repo is read only, cannot upgrade"
@@ -616,7 +654,7 @@ class Repo(object):
             return FileDataSource(fo, size)
         recipe = self.get_recipe(sum)
         if recipe:
-            reader = blobreader.RecipeReader(recipe, self, offset=offset, size=size)
+            reader = blobreader.create_recipe_reader(recipe, self, offset=offset, size=size)
             return reader
         raise ValueError("No such blob or recipe exists: "+sum)
 
@@ -726,6 +764,7 @@ class Repo(object):
         result.append(('number_of_raw_blobs', len(self.get_raw_blob_names())))
         result.append(('number_of_recipes', len(self.get_recipe_names())))
         result.append(('max_blob_size', self.get_max_blob_size()))
+        result.append(('compression', self.get_compression()))
         virtual_size = sum([self.get_blob_size(md5) for md5 in self.get_all_level_1_blobs()])
         actual_size = sum([self.get_blob_size(md5) for md5 in self.get_raw_blob_names()])
         result.append(('virtual_size', virtual_size))
@@ -1119,7 +1158,7 @@ class Transaction(object):
             full_path = self.get_recipe_path(recipe_blob)
             md5summer = hashlib.md5()
             recipe = read_json(full_path)
-            reader = blobreader.RecipeReader(recipe, self.repo, local_path=self.path)
+            reader = blobreader.create_recipe_reader(recipe, self.repo, local_path=self.path)
             while reader.bytes_left():
                 # DEDUP_BLOCK_SIZE should fit the data nicely, as
                 # a recipe will be chunked suchwise.

--- a/blobrepo/repository.py
+++ b/blobrepo/repository.py
@@ -50,6 +50,12 @@ DERIVED_SHA256_DIR = os.path.join(DERIVED_DIR, "sha256")
 DERIVED_BLOCKS_DIR = os.path.join(DERIVED_DIR, "blocks")
 DERIVED_BLOCKS_DB = os.path.join(DERIVED_BLOCKS_DIR, "blocks.db")
 DELETE_MARKER = "deleted.json"
+MAXBLOBSIZE_FILE = "maxblobsize.txt"
+
+# The smallest maximum blob size that may be configured for a
+# repository. It must be at least one deduplication block so that the
+# splitting machinery and block deduplication can coexist.
+MIN_MAX_BLOB_SIZE = 2**16
 
 REPO_DIRS_V0 = (QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR)
 REPO_DIRS_V1 = (QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR,\
@@ -95,6 +101,51 @@ blobs/bc/bc7b0fb8c2e096693acacbd6cb070f16 since the checksum starts
 with the letters "bc". The filename "testimage.jpg" is discarded. Such
 an anonymized file is called a "blob" in this document.
 
+== The recipes ==
+
+Not every blob is necessarily stored as a single raw file under
+"blobs". A blob may instead be described by a "recipe" found under the
+"recipes" directory. Recipes are used both for deduplication and to
+split large files into smaller pieces, so that a repository can be
+stored on a filesystem with a maximum file size (for instance, a
+repository on a FAT32 disk that must avoid files larger than a few
+gigabytes).
+
+Like blobs, recipes are named after the md5 checksum of the data they
+reconstruct, sorted into sub directories by the first two characters
+of the name, but with the suffix ".recipe". For instance, the recipe
+for a blob with the checksum bc7b0fb8c2e096693acacbd6cb070f16 is
+stored in recipes/bc/bc7b0fb8c2e096693acacbd6cb070f16.recipe .
+
+A recipe is a JSON document of the following form:
+
+{
+    "method": "concat",
+    "md5sum": "<checksum of the reconstructed blob>",
+    "size": <size in bytes of the reconstructed blob>,
+    "pieces": [
+        {"source": "<blob checksum>", "offset": <n>, "size": <n>, "repeat": <n>},
+        ...
+    ]
+}
+
+To reconstruct the blob, process the pieces in order. For each piece,
+read "size" bytes starting at "offset" from the raw blob named by
+"source", and append them to the output. If the optional "repeat"
+value is present and greater than 1, append that same range of bytes
+that many times in a row. The sources of a recipe are always raw
+blobs; a recipe never refers to another recipe. When you have appended
+all pieces, the result is the original file, whose checksum will match
+the recipe name.
+
+When extracting a snapshot (see below), a bloblist entry may refer to
+a checksum that exists only as a recipe. In that case, reconstruct the
+data from the recipe instead of copying a raw blob.
+
+If a maximum blob size has been configured for this repository, the
+chosen value is recorded in the file "maxblobsize.txt" in the
+repository root.
+
 == The sessions==
 
 All data files are in the JSON file format. It is quite simple, but if
@@ -139,11 +190,15 @@ def integrity_assert(test, errormsg = None):
     if not test:
         raise CorruptionError(errormsg)
 
-def create_repository(repopath, enable_deduplication = False):
+def create_repository(repopath, enable_deduplication = False, max_blob_size = None):
     if enable_deduplication and not deduplication.dedup_available:
         # Ok, we COULD create a deduplicated repo without the module,
         # but the user is likely to be confused when he cannot use it.
         raise UserError("Cannot create deduplicated repository: deduplication module is not installed")
+    if max_blob_size is not None:
+        assert isinstance(max_blob_size, int)
+        if max_blob_size < MIN_MAX_BLOB_SIZE:
+            raise UserError("Maximum blob size must be at least %s bytes" % MIN_MAX_BLOB_SIZE)
     os.mkdir(repopath)
     create_file(os.path.join(repopath, VERSION_FILE), str(LATEST_REPO_FORMAT))
     for d in QUEUE_DIR, BLOB_DIR, SESSIONS_DIR, TMP_DIR, DERIVED_DIR, DERIVED_BLOCKS_DIR, RECIPES_DIR:
@@ -153,6 +208,8 @@ def create_repository(repopath, enable_deduplication = False):
     if enable_deduplication:
         with open(os.path.join(repopath, "ENABLE_DEDUPLICATION"), "wb"):
             pass
+    if max_blob_size is not None:
+        create_file(os.path.join(repopath, MAXBLOBSIZE_FILE), str(max_blob_size))
 
 def looks_like_repo(repo_path):
     """Superficial check to see if the given path contains anything
@@ -249,6 +306,27 @@ class Repo(object):
 
     def deduplication_enabled(self):
         return os.path.exists(os.path.join(self.repopath, "ENABLE_DEDUPLICATION"))
+
+    def get_max_blob_size(self):
+        """Returns the configured maximum raw blob size in bytes, or
+        None if blobs are unbounded (the default). Files larger than
+        this limit are split into several smaller blobs that are tied
+        together with a recipe, which makes it possible to store the
+        repository on filesystems with a maximum file size."""
+        if not hasattr(self, "_max_blob_size_cache"):
+            path = os.path.join(self.repopath, MAXBLOBSIZE_FILE)
+            if os.path.exists(path):
+                raw = bytes2str(read_file(path)).strip()
+                try:
+                    value = int(raw)
+                except ValueError:
+                    raise CorruptionError("Malformed maximum blob size configuration: %r" % raw)
+                integrity_assert(value >= MIN_MAX_BLOB_SIZE,
+                                 "Illegal maximum blob size configured: %s" % value)
+                self._max_blob_size_cache = value
+            else:
+                self._max_blob_size_cache = None
+        return self._max_blob_size_cache
 
     def __upgrade_repo(self):
         assert not self.readonly, "Repo is read only, cannot upgrade"
@@ -647,6 +725,7 @@ class Repo(object):
         result.append(('number_of_user_files', len(self.get_all_level_1_blobs())))
         result.append(('number_of_raw_blobs', len(self.get_raw_blob_names())))
         result.append(('number_of_recipes', len(self.get_recipe_names())))
+        result.append(('max_blob_size', self.get_max_blob_size()))
         virtual_size = sum([self.get_blob_size(md5) for md5 in self.get_all_level_1_blobs()])
         actual_size = sum([self.get_blob_size(md5) for md5 in self.get_raw_blob_names()])
         result.append(('virtual_size', virtual_size))

--- a/blobrepo/sessions.py
+++ b/blobrepo/sessions.py
@@ -183,25 +183,51 @@ class _NaiveSessionWriter(object):
 
 
 class PieceHandler(deduplication.OriginalPieceHandler):
-    """ A PieceHandler handles all the original data for a single
-    uploaded blob. A continous length of original data is called a
-    'piece'."""
-    def __init__(self, session_dir, block_size, tmpdir, BlockifierClass):
+    """ A PieceHandler handles all the original (non-deduplicated) data
+    for a single uploaded blob. A continous length of original data is
+    called a 'piece'.
+
+    The concatenation of all original data is referred to as the
+    "amalgam". By default the amalgam is stored as a single raw blob.
+    If the repository has a maximum blob size configured, the amalgam
+    is instead split into a sequence of "sub-blobs", each no larger
+    than that limit. Either way, the resulting recipe pieces always
+    refer to raw blobs that are within the size limit.
+
+    The actual size at which sub-blobs are cut (split_size) is rounded
+    down to a whole number of deduplication blocks. That way the cut
+    points line up with block boundaries, so the deduplication blocks
+    of a freshly stored file never straddle a sub-blob boundary and
+    remain available for deduplicating future files."""
+    def __init__(self, session_dir, block_size, tmpdir, BlockifierClass, max_blob_size = None):
         assert os.path.isdir(session_dir)
         assert block_size > 0
+        assert max_blob_size is None or max_blob_size >= block_size
         self.block_size = block_size
         self.session_dir = session_dir
+        self.max_blob_size = max_blob_size
+        if max_blob_size is None:
+            self.split_size = None
+        else:
+            # Round down to a whole number of blocks (at least one).
+            self.split_size = max(block_size, (max_blob_size // block_size) * block_size)
+            assert self.split_size <= max_blob_size
         self.blockifiers = {}
         self.blocks = None
         self.piece_start_offsets = {}
         self.current_index = None
         self.tmpdir = tmpdir
         self.BlockifierClass = BlockifierClass
-        self.filename = os.path.join(self.session_dir, "amalgam")
-        assert not os.path.exists(self.filename)
-        self.fileobj = open(self.filename, "wb")
-        self.md5summer = hashlib.md5()
-        self.offset = 0
+        self.closed = False
+
+        # The amalgam is physically stored as one or more sub-blobs.
+        self.sub_blobs = [] # list of (md5, size), in amalgam order
+        self.sub_blob_starts = None # filled in by close(): virtual start offset of each sub-blob
+        self.offset = 0 # total amount of original data seen so far (virtual amalgam size)
+        self._cur_file = None
+        self._cur_summer = None
+        self._cur_size = 0
+        self._cur_tmppath = None
 
     @overrides(deduplication.OriginalPieceHandler)
     def init_piece(self, index):
@@ -213,14 +239,58 @@ class PieceHandler(deduplication.OriginalPieceHandler):
         self.piece_start_offsets[index] = self.offset
         self.current_index = index
 
+    def __open_sub_blob(self):
+        assert self._cur_file == None
+        self._cur_tmppath = tempfile.mktemp(prefix = "amalgam_", dir = self.session_dir)
+        self._cur_file = open(self._cur_tmppath, "wb")
+        self._cur_summer = hashlib.md5()
+        self._cur_size = 0
+
+    def __finalize_sub_blob(self):
+        assert self._cur_file != None
+        self._cur_file.close()
+        self._cur_file = None
+        md5 = self._cur_summer.hexdigest()
+        real_name = os.path.join(self.session_dir, md5)
+        # An identical sub-blob may already have been written during
+        # this commit. If so, just drop our copy.
+        if os.path.exists(real_name):
+            # Necessary for windows. Posix silently replaces an existing file.
+            safe_delete_file(self._cur_tmppath)
+        else:
+            os.rename(self._cur_tmppath, real_name)
+        self.sub_blobs.append((md5, self._cur_size))
+        self._cur_tmppath = None
+        self._cur_summer = None
+        self._cur_size = 0
+
     @overrides(deduplication.OriginalPieceHandler)
     def add_piece_data(self, index, data):
         assert self.current_index == index
-        self.fileobj.write(data)
-        self.md5summer.update(data)
+        assert not self.closed
+        # The deduplication blockifier always sees the full data,
+        # independent of how it is physically split into sub-blobs.
         self.blockifiers[index].feed_string(data)
-        self.offset += len(data)
-        #print "Adding", len(data), "bytes"
+        view = memoryview(data)
+        pos = 0
+        total = len(data)
+        while pos < total:
+            if self._cur_file == None:
+                self.__open_sub_blob()
+            if self.split_size == None:
+                take = total - pos
+            else:
+                space = self.split_size - self._cur_size
+                assert space > 0
+                take = min(total - pos, space)
+            chunk = view[pos:pos + take]
+            self._cur_file.write(chunk)
+            self._cur_summer.update(chunk)
+            self._cur_size += take
+            self.offset += take
+            pos += take
+            if self.split_size != None and self._cur_size == self.split_size:
+                self.__finalize_sub_blob()
 
     @overrides(deduplication.OriginalPieceHandler)
     def end_piece(self, index):
@@ -231,29 +301,106 @@ class PieceHandler(deduplication.OriginalPieceHandler):
 
     @overrides(deduplication.OriginalPieceHandler)
     def close(self):
-        self.fileobj.close()
-        self.fileobj = None
-        self.final_md5 = self.md5summer.hexdigest()
-        real_name = os.path.join(self.session_dir, self.final_md5)
+        assert not self.closed
+        self.closed = True
+        # Finalize any partially-filled trailing sub-blob. If there was
+        # no original data at all, no sub-blob is created.
+        if self._cur_file != None:
+            self.__finalize_sub_blob()
 
-        # The piece may already have been added during this commit. If
-        # so, just ignore it.
-        if os.path.exists(real_name):
-            # Necessary for windows. Posix silently replaces an existing file.
-            safe_delete_file(self.filename)
-        else:
-            os.rename(self.filename, real_name)
+        if not self.sub_blobs and self.blockifiers:
+            # There was at least one original piece, but it carried no
+            # data at all (an empty file). Materialize a single empty
+            # sub-blob so that the zero-length piece can still be
+            # represented in the recipe, exactly as before.
+            self.__open_sub_blob()
+            self.__finalize_sub_blob()
 
+        # Compute the virtual start offset of each sub-blob.
+        self.sub_blob_starts = []
+        acc = 0
+        for md5, size in self.sub_blobs:
+            self.sub_blob_starts.append(acc)
+            acc += size
+        assert acc == self.offset, "Sub-blobs do not account for all original data"
+
+        # Harvest deduplication blocks, mapping each to the sub-blob
+        # that physically contains it. A block that straddles a
+        # sub-blob boundary cannot be addressed as a single (blob,
+        # offset) location, so it is simply dropped - it just won't be
+        # available for future deduplication.
         self.blocks = []
         for index, blockifier in list(self.blockifiers.items()):
+            piece_start = self.piece_start_offsets[index]
             for offset, rolling, md5 in blockifier.harvest():
-                self.blocks.append((self.final_md5, self.piece_start_offsets[index] + offset, rolling, md5))
+                location = self.__locate(piece_start + offset, self.block_size)
+                if location != None:
+                    sub_md5, offset_in_blob = location
+                    self.blocks.append((sub_md5, offset_in_blob, rolling, md5))
 
+    def __locate(self, virtual_offset, length):
+        """If the range [virtual_offset, virtual_offset+length) lies
+        entirely within a single sub-blob, return a (sub_blob_md5,
+        offset_within_sub_blob) tuple. Otherwise (the range straddles a
+        boundary or lies outside the amalgam) return None."""
+        assert self.closed
+        if self.split_size == None:
+            if not self.sub_blobs:
+                return None
+            md5, size = self.sub_blobs[0]
+            if virtual_offset + length <= size:
+                return md5, virtual_offset
+            return None
+        index = virtual_offset // self.split_size
+        if index != (virtual_offset + length - 1) // self.split_size:
+            return None # straddles a sub-blob boundary
+        if index >= len(self.sub_blobs):
+            return None
+        md5, size = self.sub_blobs[index]
+        offset_in_blob = virtual_offset - index * self.split_size
+        assert offset_in_blob + length <= size
+        return md5, offset_in_blob
 
     @overrides(deduplication.OriginalPieceHandler)
-    def get_piece_address(self, index):
-        assert self.fileobj == None
-        return self.final_md5, self.piece_start_offsets[index]
+    def get_piece_segments(self, index, size):
+        """Return a list of (sub_blob_md5, offset, size) segments that,
+        concatenated in order, reproduce the original piece's data. A
+        single piece may be spread over several sub-blobs when a
+        maximum blob size is configured."""
+        assert self.closed
+        return self.__map_range(self.piece_start_offsets[index], size)
+
+    def __map_range(self, virtual_offset, length):
+        segments = []
+        pos = virtual_offset
+        remaining = length
+        if length == 0:
+            # Zero-length piece (an empty file). Reference the sub-blob
+            # containing this position with a zero-length segment, so
+            # the recipe still contains a piece for it.
+            index = 0 if self.split_size == None else virtual_offset // self.split_size
+            if index < len(self.sub_blobs):
+                md5, size = self.sub_blobs[index]
+                sub_start = 0 if self.split_size == None else index * self.split_size
+                segments.append((md5, virtual_offset - sub_start, 0))
+            return segments
+        while remaining > 0:
+            if self.split_size == None:
+                index = 0
+                sub_start = 0
+            else:
+                index = pos // self.split_size
+                sub_start = index * self.split_size
+            assert index < len(self.sub_blobs), \
+                "Original data range exceeds the stored sub-blobs"
+            md5, size = self.sub_blobs[index]
+            offset_in_blob = pos - sub_start
+            segment_size = min(remaining, size - offset_in_blob)
+            assert segment_size > 0
+            segments.append((md5, offset_in_blob, segment_size))
+            pos += segment_size
+            remaining -= segment_size
+        return segments
 
 class SessionWriter(object):
     def __init__(self, repo, session_name, base_session = None, session_id = None, force_base_snapshot = False):
@@ -266,7 +413,7 @@ class SessionWriter(object):
         self.repo = repo
         self.tmpblocksdb = deduplication.TmpBlocksDB(self.repo.blocksdb)
         self.session_name = session_name
-        self.max_blob_size = None
+        self.max_blob_size = repo.get_max_blob_size()
         self.base_session = base_session
         self.force_base_snapshot = force_base_snapshot
         self.metadatas = {}
@@ -340,7 +487,8 @@ class SessionWriter(object):
                                        blobsource,
                                        PieceHandler(self.session_path, repository.DEDUP_BLOCK_SIZE,
                                                     tmpdir = self.repo.get_tmpdir(),
-                                                    BlockifierClass = blockifierclass),
+                                                    BlockifierClass = blockifierclass,
+                                                    max_blob_size = self.max_blob_size),
                                        tmpdir = self.repo.get_tmpdir(),
                                        RollingChecksumClass = rollingchecksumclass)
 

--- a/blobrepo/sessions.py
+++ b/blobrepo/sessions.py
@@ -32,6 +32,7 @@ from common import *
 from boar_common import *
 
 import deduplication
+import compression
 
 """
 The SessionWriter and SessionReader are together with Repository the
@@ -402,6 +403,99 @@ class PieceHandler(deduplication.OriginalPieceHandler):
             remaining -= segment_size
         return segments
 
+class CompressingBlobWriter(object):
+    """Compresses a single uploaded blob with a streaming codec and stores
+    the resulting compressed data as one or more raw "sub-blobs". If the
+    repository has a maximum blob size configured, the compressed stream is
+    split so that no sub-blob exceeds the limit. The blob is then described
+    by a "compress" recipe whose pieces concatenate back into the
+    compressed data.
+
+    Compression replaces (does not stack with) deduplication: the
+    compressed byte stream defeats block matching, so no deduplication
+    blocks are harvested for compressed blobs."""
+
+    def __init__(self, session_dir, algorithm, max_blob_size = None):
+        assert os.path.isdir(session_dir)
+        assert max_blob_size is None or max_blob_size > 0
+        self.session_dir = session_dir
+        self.algorithm = algorithm
+        self.compressor = compression.get_codec(algorithm).compressor()
+        self.max_blob_size = max_blob_size
+        self.uncompressed_md5 = hashlib.md5()
+        self.uncompressed_size = 0
+        self.sub_blobs = [] # list of (md5, size), in order
+        self.closed = False
+        self._cur_file = None
+        self._cur_summer = None
+        self._cur_size = 0
+        self._cur_tmppath = None
+
+    def feed(self, data):
+        assert not self.closed
+        assert type(data) == bytes
+        self.uncompressed_md5.update(data)
+        self.uncompressed_size += len(data)
+        compressed = self.compressor.compress(data)
+        if compressed:
+            self.__write(compressed)
+
+    def __open_sub_blob(self):
+        assert self._cur_file == None
+        self._cur_tmppath = tempfile.mktemp(prefix = "compressed_", dir = self.session_dir)
+        self._cur_file = open(self._cur_tmppath, "wb")
+        self._cur_summer = hashlib.md5()
+        self._cur_size = 0
+
+    def __finalize_sub_blob(self):
+        assert self._cur_file != None
+        self._cur_file.close()
+        self._cur_file = None
+        md5 = self._cur_summer.hexdigest()
+        real_name = os.path.join(self.session_dir, md5)
+        if os.path.exists(real_name):
+            safe_delete_file(self._cur_tmppath)
+        else:
+            os.rename(self._cur_tmppath, real_name)
+        self.sub_blobs.append((md5, self._cur_size))
+        self._cur_tmppath = None
+        self._cur_summer = None
+        self._cur_size = 0
+
+    def __write(self, data):
+        view = memoryview(data)
+        pos = 0
+        total = len(data)
+        while pos < total:
+            if self._cur_file == None:
+                self.__open_sub_blob()
+            if self.max_blob_size == None:
+                take = total - pos
+            else:
+                space = self.max_blob_size - self._cur_size
+                assert space > 0
+                take = min(total - pos, space)
+            chunk = view[pos:pos + take]
+            self._cur_file.write(chunk)
+            self._cur_summer.update(chunk)
+            self._cur_size += take
+            pos += take
+            if self.max_blob_size != None and self._cur_size == self.max_blob_size:
+                self.__finalize_sub_blob()
+
+    def close(self):
+        assert not self.closed
+        self.closed = True
+        tail = self.compressor.flush()
+        if tail:
+            self.__write(tail)
+        if self._cur_file != None:
+            self.__finalize_sub_blob()
+        # Every codec emits at least a container header on flush, so there
+        # is always at least one sub-blob, even for an empty input.
+        assert self.sub_blobs, "Compressor produced no output"
+
+
 class SessionWriter(object):
     def __init__(self, repo, session_name, base_session = None, session_id = None, force_base_snapshot = False):
         assert session_name and isinstance(session_name, str)
@@ -419,6 +513,10 @@ class SessionWriter(object):
         self.metadatas = {}
         self.found_uncommitted_blocks = []
         self.blob_deduplicator = {}
+        # When compression is enabled it takes precedence over
+        # deduplication for storing blob data (the two do not stack).
+        self.compression = repo.get_compression()
+        self.compress_writers = {}
 
         all_rolling = self.repo.blocksdb.get_all_rolling()
         self.rolling_set = deduplication.CreateIntegerSet(all_rolling)
@@ -470,6 +568,10 @@ class SessionWriter(object):
         # here. Possibly some other session is uploading, or has
         # uploaded this blob, before we get here. But that is ok.
         assert not self.dead
+        if self.compression:
+            self.compress_writers[blob_md5] = CompressingBlobWriter(
+                self.session_path, self.compression, self.max_blob_size)
+            return
         if self.repo.deduplication_enabled():
             assert deduplication.dedup_available, "Deduplication module not available"
             rollingchecksumclass = deduplication.RollingChecksum
@@ -498,9 +600,38 @@ class SessionWriter(object):
         assert is_md5sum(blob_md5)
         assert not self.dead
         assert type(fragment) == bytes
+        if blob_md5 in self.compress_writers:
+            self.compress_writers[blob_md5].feed(fragment)
+            return
         self.blob_deduplicator[blob_md5].feed(fragment)
 
+    def __blob_finished_compressed(self, blob_md5):
+        writer = self.compress_writers[blob_md5]
+        writer.close()
+        assert writer.uncompressed_md5.hexdigest() == blob_md5, \
+            "Compressed data does not match the promised checksum"
+        assert writer.sub_blobs, "A compressed blob must have at least one piece"
+        recipe = {
+            "method": "compress",
+            "algorithm": writer.algorithm,
+            "md5sum": blob_md5,
+            "size": writer.uncompressed_size,
+            "compressed_size": sum(size for md5, size in writer.sub_blobs),
+            "pieces": [{"source": md5, "offset": 0, "size": size}
+                       for md5, size in writer.sub_blobs],
+        }
+        recipe_json_bytes = str2bytes(json.dumps(recipe, indent = 4))
+        recipe_md5 = md5sum(recipe_json_bytes)
+        recipe_path = os.path.join(self.session_path, blob_md5 + ".recipe")
+        if not os.path.exists(recipe_path): # If it already exists, don't write it again
+            with StrictFileWriter(recipe_path, recipe_md5, len(recipe_json_bytes)) as recipe_file:
+                recipe_file.write(recipe_json_bytes)
+        del self.compress_writers[blob_md5]
+
     def blob_finished(self, blob_md5):
+        if blob_md5 in self.compress_writers:
+            self.__blob_finished_compressed(blob_md5)
+            return
         sw = StopWatch(enabled=False, name="session.blob_finished")
         self.blob_deduplicator[blob_md5].close()
         for block in self.blob_deduplicator[blob_md5].original_piece_handler.blocks:
@@ -592,8 +723,14 @@ class SessionWriter(object):
             recipe_path = os.path.join(self.session_path, blob_name + ".recipe")
             assert os.path.exists(blob_path) or os.path.exists(recipe_path),\
                 "a blob in the commit disappeared after deduplication"
-            assert not(os.path.exists(blob_path) and os.path.exists(recipe_path)),\
-                "a blob in the commit exists as both raw blob and recipe"
+            if os.path.exists(blob_path) and os.path.exists(recipe_path):
+                # The same md5 can name both a raw blob and a recipe when a
+                # compressed sub-blob's (compressed) checksum happens to
+                # equal another file's (uncompressed) checksum. Both are
+                # content-addressed to this md5, so they hold identical
+                # data; keep the raw blob (authoritative, no decoding
+                # needed) and drop the now-redundant recipe.
+                safe_delete_recipe(recipe_path)
 
         if self.force_base_snapshot:
             bloblist = list(self.resulting_blobdict.values())

--- a/boar
+++ b/boar
@@ -441,6 +441,10 @@ def cmd_mkrepo(args):
                       "blobs tied together with a recipe. This makes it possible to keep "
                       "the repository on a filesystem with a maximum file size. SIZE may "
                       "use the suffixes k, M, G or T (powers of 1024), for example '2G'.")
+    parser.add_option("-c", "--compress", dest = "compress", metavar="ALGORITHM",
+                      help="Store all blob data compressed with ALGORITHM (one of: "
+                      "gzip, xz, bz2, lz4). Make sure you will be able to decode the "
+                      "chosen algorithm in the future.")
     (options, args) = parser.parse_args(args)
     if len(args) > 1:
         raise UserError("Too many arguments")
@@ -454,7 +458,8 @@ def cmd_mkrepo(args):
         except ValueError as e:
             raise UserError("Invalid --max-file-size value: %s" % e)
     repository.create_repository(repopath, enable_deduplication = options.dedup,
-                                 max_blob_size = max_blob_size)
+                                 max_blob_size = max_blob_size,
+                                 compression_algorithm = options.compress)
 
 def cmd_list(args):
     parser = OptionParser(usage="usage: boar list [session name [snapshot id]]")

--- a/boar
+++ b/boar
@@ -433,16 +433,28 @@ def cmd_info(args):
 def cmd_mkrepo(args):
     if len(args) == 0:
         args = ["--help"]
-    parser = OptionParser(usage="usage: boar mkrepo [-d|--enable-deduplication] <new repo path>")
+    parser = OptionParser(usage="usage: boar mkrepo [-d|--enable-deduplication] [-m|--max-file-size SIZE] <new repo path>")
     parser.add_option("-d", "--enable-deduplication", dest = "dedup", action="store_true",
                       help="Enable deduplication for this repository")
+    parser.add_option("-m", "--max-file-size", dest = "max_file_size", metavar="SIZE",
+                      help="Store files larger than SIZE by splitting them into smaller "
+                      "blobs tied together with a recipe. This makes it possible to keep "
+                      "the repository on a filesystem with a maximum file size. SIZE may "
+                      "use the suffixes k, M, G or T (powers of 1024), for example '2G'.")
     (options, args) = parser.parse_args(args)
     if len(args) > 1:
         raise UserError("Too many arguments")
     repopath, = args
     if os.path.exists(repopath):
         raise UserError("File or directory already exists: %s" % repopath)
-    repository.create_repository(repopath, enable_deduplication = options.dedup)
+    max_blob_size = None
+    if options.max_file_size is not None:
+        try:
+            max_blob_size = parse_human_size(options.max_file_size)
+        except ValueError as e:
+            raise UserError("Invalid --max-file-size value: %s" % e)
+    repository.create_repository(repopath, enable_deduplication = options.dedup,
+                                 max_blob_size = max_blob_size)
 
 def cmd_list(args):
     parser = OptionParser(usage="usage: boar list [session name [snapshot id]]")

--- a/common.py
+++ b/common.py
@@ -22,6 +22,7 @@ import platform
 import locale
 import codecs
 import errno
+import math
 import time
 import textwrap
 import stat as statmod
@@ -178,6 +179,40 @@ def read_md5sum(path, expected_md5 = None):
     non-utf-8 files is md5sum.exe on Windows."""
     data = read_file(path, expected_md5).decode("utf-8-sig")
     return parse_md5sum(data)
+
+def parse_human_size(s):
+    """Parse a human-friendly size string into a number of bytes.
+
+    Accepts a plain integer ("65536") or a number followed by one of
+    the binary suffixes k, M, G or T (powers of 1024,
+    case-insensitive). An optional trailing 'b'/'B' is allowed, so
+    "5M", "5MB", "5mb" and "5242880" all mean the same thing. Decimal
+    values such as "1.5G" are accepted. Raises ValueError on malformed
+    input or negative values."""
+    assert isinstance(s, str)
+    text = s.strip().lower()
+    if not text:
+        raise ValueError("Empty size string")
+    if text.endswith("b"):
+        # Allow an explicit byte marker, e.g. "100b" or "5mb".
+        text = text[:-1]
+    units = {'k': 1024, 'm': 1024 ** 2, 'g': 1024 ** 3, 't': 1024 ** 4}
+    multiplier = 1
+    if text and text[-1] in units:
+        multiplier = units[text[-1]]
+        text = text[:-1]
+    text = text.strip()
+    if not text:
+        raise ValueError("Malformed size: %r" % s)
+    try:
+        value = float(text)
+    except ValueError:
+        raise ValueError("Malformed size: %r" % s)
+    if not math.isfinite(value):
+        raise ValueError("Malformed size: %r" % s)
+    if value < 0:
+        raise ValueError("Size must not be negative: %r" % s)
+    return int(value * multiplier)
 
 _file_reader_sum = 0
 def file_reader(f, start = 0, end = None, blocksize = 2 ** 16):

--- a/compression.py
+++ b/compression.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2010 Mats Ekberg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable, streaming (de)compression codecs for blob recipes.
+
+A repository can be configured to store all blob data compressed with a
+chosen algorithm. The algorithm name is recorded in each "compress"
+recipe, so reading a blob only requires the matching codec to be
+available - boar itself is algorithm agnostic and stores the data in the
+algorithm's standard container format. It is the user's responsibility
+to pick an algorithm they will still be able to decode later.
+
+Every codec exposes two tiny streaming interfaces:
+
+  compressor():  an object with
+      .compress(data) -> bytes      # feed more uncompressed data
+      .flush()        -> bytes      # finish, returning the last bytes
+
+  decompressor(): an object with
+      .decompress(data, max_length) -> bytes  # up to max_length bytes out
+      .needs_input  (property, bool)          # True if more input is wanted
+      .eof          (property, bool)          # True once the stream ended
+
+The decompressor model matches the stdlib lzma/bz2 decompressors: feed
+compressed input, repeatedly drain output (passing b"" as input) until
+needs_input becomes True again, and stop when eof is True.
+"""
+
+from boar_exceptions import UserError
+
+import zlib
+
+
+# --- gzip (zlib) -----------------------------------------------------------
+
+class _ZlibCompressor(object):
+    def __init__(self, level=6):
+        # wbits=31 selects the gzip container (16) plus the maximum
+        # window (15), so the produced blobs are ordinary .gz streams.
+        self._c = zlib.compressobj(level, zlib.DEFLATED, 31)
+
+    def compress(self, data):
+        return self._c.compress(data)
+
+    def flush(self):
+        return self._c.flush()
+
+
+class _ZlibDecompressor(object):
+    def __init__(self):
+        self._d = zlib.decompressobj(31)
+        self._tail = b""
+
+    def decompress(self, data, max_length):
+        assert max_length > 0
+        self._tail = self._tail + data
+        out = self._d.decompress(self._tail, max_length)
+        self._tail = self._d.unconsumed_tail
+        return out
+
+    @property
+    def eof(self):
+        return self._d.eof
+
+    @property
+    def needs_input(self):
+        return not self._tail
+
+
+# --- xz (lzma) and bz2 -----------------------------------------------------
+
+class _NativeDecompressor(object):
+    """Adapter for the stdlib lzma/bz2 decompressors, which already buffer
+    their input internally and expose needs_input/eof."""
+    def __init__(self, raw):
+        self._d = raw
+
+    def decompress(self, data, max_length):
+        assert max_length > 0
+        return self._d.decompress(data, max_length)
+
+    @property
+    def eof(self):
+        return self._d.eof
+
+    @property
+    def needs_input(self):
+        return self._d.needs_input
+
+
+def _lzma_compressor():
+    import lzma
+    return lzma.LZMACompressor()  # FORMAT_XZ container by default
+
+
+def _lzma_decompressor():
+    import lzma
+    return _NativeDecompressor(lzma.LZMADecompressor())
+
+
+def _bz2_compressor():
+    import bz2
+    return bz2.BZ2Compressor()
+
+
+def _bz2_decompressor():
+    import bz2
+    return _NativeDecompressor(bz2.BZ2Decompressor())
+
+
+# --- lz4 (frame format) ----------------------------------------------------
+
+class _Lz4Compressor(object):
+    def __init__(self):
+        import lz4.frame
+        self._c = lz4.frame.LZ4FrameCompressor()
+        self._begun = False
+
+    def __begin(self):
+        if self._begun:
+            return b""
+        self._begun = True
+        return self._c.begin()
+
+    def compress(self, data):
+        return self.__begin() + self._c.compress(data)
+
+    def flush(self):
+        # Ensure a valid (possibly empty) frame is produced even if no
+        # data was ever fed.
+        return self.__begin() + self._c.flush()
+
+
+def _lz4_decompressor():
+    import lz4.frame
+    return _NativeDecompressor(lz4.frame.LZ4FrameDecompressor())
+
+
+# --- registry --------------------------------------------------------------
+
+class _Codec(object):
+    def __init__(self, name, module, compressor_factory, decompressor_factory):
+        self.name = name
+        self._module = module          # importable module name, or None for builtins
+        self._compressor = compressor_factory
+        self._decompressor = decompressor_factory
+
+    def available(self):
+        if self._module is None:
+            return True
+        try:
+            __import__(self._module)
+            return True
+        except ImportError:
+            return False
+
+    def compressor(self):
+        return self._compressor()
+
+    def decompressor(self):
+        return self._decompressor()
+
+
+_CODECS = {
+    "gzip": _Codec("gzip", None, _ZlibCompressor, _ZlibDecompressor),
+    "xz":   _Codec("xz", "lzma", _lzma_compressor, _lzma_decompressor),
+    "bz2":  _Codec("bz2", "bz2", _bz2_compressor, _bz2_decompressor),
+    "lz4":  _Codec("lz4", "lz4.frame", _Lz4Compressor, _lz4_decompressor),
+}
+
+# Aliases the CLI and recipes will accept, mapped to a canonical name.
+_ALIASES = {
+    "gz": "gzip",
+    "zlib": "gzip",
+    "lzma": "xz",
+    "bzip2": "bz2",
+}
+
+KNOWN_ALGORITHMS = tuple(_CODECS.keys())
+
+
+def canonical_name(name):
+    """Return the canonical algorithm name for the given (possibly
+    aliased, possibly mixed-case) name. Returns the lower-cased input
+    unchanged if it is not recognised."""
+    assert isinstance(name, str)
+    key = name.strip().lower()
+    return _ALIASES.get(key, key)
+
+
+def is_known(name):
+    return canonical_name(name) in _CODECS
+
+
+def is_available(name):
+    """True if the named algorithm is both known and its codec module can
+    be imported in this environment."""
+    canon = canonical_name(name)
+    codec = _CODECS.get(canon)
+    return bool(codec) and codec.available()
+
+
+def get_codec(name):
+    """Return the codec for the named algorithm. Raises UserError if the
+    algorithm is unknown or its module is not installed."""
+    canon = canonical_name(name)
+    codec = _CODECS.get(canon)
+    if codec is None:
+        raise UserError("Unknown compression algorithm: %s (known: %s)" %
+                        (name, ", ".join(sorted(_CODECS.keys()))))
+    if not codec.available():
+        raise UserError("The '%s' compression algorithm is not available - "
+                        "the required module is not installed." % canon)
+    return codec

--- a/deduplication.py
+++ b/deduplication.py
@@ -216,6 +216,16 @@ class OriginalPieceHandler(object):
         recipe."""
         pass
 
+    def get_piece_segments(self, index, size):
+        """After the handler has been closed, this method must return a
+        list of (blob, offset, size) segments that, concatenated in
+        order, reproduce the data of the given piece. The default
+        implementation stores each piece in a single blob and so
+        returns a single segment; handlers that split data across
+        several blobs override this."""
+        blob, offset = self.get_piece_address(index)
+        return [(blob, offset, size)]
+
 from statemachine import GenericStateMachine
 
 START_STATE = "START"
@@ -433,10 +443,15 @@ class RecipeFinder(GenericStateMachine):
 
         for s in self.sequences:
             if isinstance(s, Struct):
-                # Original data
-                restored_size += s.piece_size
-                blob, offset = s.piece_handler.get_piece_address(s.piece_index)
-                yield get_dict(blob, offset, s.piece_size, True)
+                # Original data. The piece may be spread over several
+                # blobs if a maximum blob size is configured, so emit
+                # one recipe piece per stored segment.
+                segment_total = 0
+                for blob, offset, segment_size in s.piece_handler.get_piece_segments(s.piece_index, s.piece_size):
+                    segment_total += segment_size
+                    restored_size += segment_size
+                    yield get_dict(blob, offset, segment_size, True)
+                assert segment_total == s.piece_size
 
             elif type(s) == list:
                 # Duplicated data

--- a/front.py
+++ b/front.py
@@ -589,7 +589,9 @@ class Front(object):
 
     def new_snapshot_has_blob(self, sum):
         assert self.new_session, "new_snapshot_has_blob() must only be called when a new snapshot is underway"
-        return self.new_session.has_blob(sum)
+        # A blob already uploaded in this snapshot may be stored either
+        # as a raw blob or, for oversized/deduplicated files, as a recipe.
+        return self.new_session.has_blob(sum) or self.new_session.has_recipe(sum)
 
     def find_last_revision(self, session_name):
         """ Returns the id of the latest snapshot in the specified
@@ -633,6 +635,9 @@ class Front(object):
 
     def deduplication_enabled(self):
         return self.repo.deduplication_enabled()
+
+    def get_max_blob_size(self):
+        return self.repo.get_max_blob_size()
 
 class DryRunFront(object):
 

--- a/front.py
+++ b/front.py
@@ -639,6 +639,9 @@ class Front(object):
     def get_max_blob_size(self):
         return self.repo.get_max_blob_size()
 
+    def get_compression(self):
+        return self.repo.get_compression()
+
 class DryRunFront(object):
 
     def __init__(self, front):

--- a/macrotests/test_compression.sh
+++ b/macrotests/test_compression.sh
@@ -1,0 +1,101 @@
+# Tests for the blob compression feature: a repository may store all blob
+# data compressed with a chosen algorithm, described by a "compress" recipe.
+
+TESTDIR="`pwd`"
+BIGFILE=$TESTDIR/bigfile.bin
+
+# A deterministic ~1 MB file (same one used by test_recipes.sh).
+python3 "${BOARTESTHOME}/mkrandfile.py" 0 1000000 $BIGFILE || exit 1
+md5sum -c <<EOF || exit 1
+d978f6138c52b8be4f07bbbf571cd450  $BIGFILE
+EOF
+BIGMD5=d978f6138c52b8be4f07bbbf571cd450
+
+# gzip and xz are always available (Python standard library). lz4 needs the
+# optional module - test it only when present.
+ALGOS="gzip xz"
+if python3 -c "import lz4.frame" 2>/dev/null; then
+    ALGOS="$ALGOS lz4"
+fi
+
+for ALGO in $ALGOS; do
+    echo "*** Compression algorithm: $ALGO"
+    REPO=$TESTDIR/repo_$ALGO
+    $BOAR mkrepo --compress $ALGO $REPO || exit 1
+    test "`cat $REPO/compression.txt`" = "$ALGO" || { echo "Wrong compression.txt for $ALGO"; exit 1; }
+
+    $BOAR --repo=$REPO mksession S || exit 1
+    $BOAR --repo=$REPO co S || exit 1
+    (cd S &&
+        cp $BIGFILE big.bin &&
+        printf 'small compressible text, repeated. ' >small.txt &&
+        for i in $(seq 1 100); do printf 'small compressible text, repeated. ' >>small.txt; done &&
+        md5sum big.bin small.txt >manifest.md5 &&
+        $BOAR ci -q ) || exit 1
+
+    # The big file must be stored as a "compress" recipe, not a raw blob.
+    RECIPE=$REPO/recipes/d9/$BIGMD5.recipe
+    test -e "$RECIPE" || { echo "Expected compress recipe missing for $ALGO"; exit 1; }
+    test ! -e $REPO/blobs/d9/$BIGMD5 || { echo "Oversized file should not be a raw blob ($ALGO)"; exit 1; }
+    python3 -c "import json,sys; r=json.load(open('$RECIPE')); sys.exit(0 if r['method']=='compress' and r['algorithm']=='$ALGO' else 1)" \
+        || { echo "Recipe method/algorithm wrong for $ALGO"; exit 1; }
+
+    # The small, highly compressible file must actually shrink on disk.
+    SMALLMD5=`md5sum S/small.txt | cut -d' ' -f1`
+    SMALLRECIPE=$REPO/recipes/${SMALLMD5:0:2}/$SMALLMD5.recipe
+    stored=`python3 -c "import json,os; r=json.load(open('$SMALLRECIPE')); print(sum(os.path.getsize('$REPO/blobs/'+p['source'][:2]+'/'+p['source']) for p in r['pieces']))"`
+    orig=`stat -c%s S/small.txt`
+    test "$stored" -lt "$orig" || { echo "Compressible file did not shrink ($ALGO): $orig -> $stored"; exit 1; }
+
+    $BOAR --repo=$REPO verify || { echo "Verify failed ($ALGO)"; exit 1; }
+    rm -r S || exit 1
+    $BOAR --repo=$REPO co S || { echo "Checkout failed ($ALGO)"; exit 1; }
+    (cd S && md5sum -c manifest.md5 ) || exit 1
+    rm -r S || exit 1
+done
+
+############################################################
+echo "*** A gzip source blob is a standard .gz, recoverable with gunzip"
+
+REPO=$TESTDIR/repo_recover
+$BOAR mkrepo --compress gzip $REPO || exit 1
+$BOAR --repo=$REPO mksession S >/dev/null || exit 1
+$BOAR --repo=$REPO co S >/dev/null || exit 1
+(cd S && printf 'recover me with standard tools\n' >note.txt && $BOAR ci -q ) || exit 1
+NOTEMD5=`md5sum S/note.txt | cut -d' ' -f1`
+SRC=`python3 -c "import json; print(json.load(open('$REPO/recipes/${NOTEMD5:0:2}/$NOTEMD5.recipe'))['pieces'][0]['source'])"`
+gunzip -c $REPO/blobs/${SRC:0:2}/$SRC >recovered.txt || { echo "gunzip of source blob failed"; exit 1; }
+diff S/note.txt recovered.txt || { echo "gunzip recovery mismatch"; exit 1; }
+rm -r S $REPO recovered.txt || exit 1
+
+############################################################
+echo "*** Compression combined with a maximum blob size splits the compressed stream"
+
+REPO=$TESTDIR/repo_split
+$BOAR mkrepo --compress gzip --max-file-size 64k $REPO || exit 1
+$BOAR --repo=$REPO mksession S >/dev/null || exit 1
+$BOAR --repo=$REPO co S >/dev/null || exit 1
+# The big random file barely compresses, so the compressed stream still
+# exceeds 64k and must be split into several sub-blobs.
+(cd S && cp $BIGFILE big.bin && md5sum big.bin >manifest.md5 && $BOAR ci -q ) || exit 1
+if [ -n "`find $REPO/blobs -type f -size +65536c`" ]; then
+    echo "Found a blob larger than the 64k limit:"; find $REPO/blobs -type f -size +65536c -printf '%s %p\n'; exit 1
+fi
+$BOAR --repo=$REPO verify || { echo "Verify (compress+split) failed"; exit 1; }
+rm -r S || exit 1
+$BOAR --repo=$REPO co S || { echo "Checkout (compress+split) failed"; exit 1; }
+(cd S && md5sum -c manifest.md5 ) || exit 1
+rm -r S || exit 1
+
+############################################################
+echo "*** Cloning a compressed repo into a plain repo reassembles the data"
+
+CLONE=$TESTDIR/clone_plain
+$BOAR clone $REPO $CLONE || { echo "Clone failed"; exit 1; }
+test ! -e $CLONE/compression.txt || { echo "Plain clone unexpectedly compressed"; exit 1; }
+$BOAR --repo=$CLONE verify || { echo "Plain clone verify failed"; exit 1; }
+$BOAR --repo=$CLONE co S || { echo "Plain clone checkout failed"; exit 1; }
+(cd S && md5sum -c manifest.md5 ) || exit 1
+rm -r S $REPO $CLONE || exit 1
+
+exit 0

--- a/macrotests/test_maxblobsize.sh
+++ b/macrotests/test_maxblobsize.sh
@@ -1,0 +1,137 @@
+# Tests for the "maximum blob size" feature: files larger than the
+# configured limit are split into several smaller blobs tied together
+# with a recipe, so that the repository can live on a filesystem with a
+# maximum file size.
+
+TESTDIR="`pwd`"
+REPO=$TESTDIR/repo
+BIGFILE=$TESTDIR/bigfile.bin
+
+MAX=102400 # 100 KiB, the limit used for $REPO
+
+# A deterministic ~1 MB file (same one used by test_recipes.sh).
+python3 "${BOARTESTHOME}/mkrandfile.py" 0 1000000 $BIGFILE || exit 1
+md5sum -c <<EOF || exit 1
+d978f6138c52b8be4f07bbbf571cd450  $BIGFILE
+EOF
+BIGMD5=d978f6138c52b8be4f07bbbf571cd450
+
+assert_no_blob_over () {
+    # assert_no_blob_over <repo> <limit-in-bytes>
+    local repo="$1"; local limit="$2"
+    local toobig
+    toobig=`find "$repo/blobs" -type f -size +${limit}c`
+    if [ -n "$toobig" ]; then
+        echo "*** FAIL: found blob(s) larger than $limit bytes in $repo:"
+        find "$repo/blobs" -type f -size +${limit}c -printf '%s %p\n'
+        exit 1
+    fi
+}
+
+############################################################
+echo "*** Splitting without deduplication"
+
+$BOAR mkrepo --max-file-size 100k $REPO || exit 1
+test "`cat $REPO/maxblobsize.txt`" = "102400" || { echo "Wrong maxblobsize.txt contents"; exit 1; }
+
+$BOAR --repo=$REPO mksession Big || exit 1
+$BOAR --repo=$REPO co Big || exit 1
+(cd Big &&
+    cp $BIGFILE bigfile.bin &&
+    md5sum bigfile.bin >manifest.md5 &&
+    $BOAR ci -q ) || exit 1
+
+assert_no_blob_over $REPO $MAX
+# The oversized file must be stored as a recipe, not a raw blob.
+test -e $REPO/recipes/d9/$BIGMD5.recipe || { echo "Expected recipe is missing"; exit 1; }
+test ! -e $REPO/blobs/d9/$BIGMD5 || { echo "Oversized file should not be a raw blob"; exit 1; }
+
+$BOAR --repo=$REPO verify || { echo "Verify failed"; exit 1; }
+rm -r Big || exit 1
+$BOAR --repo=$REPO co Big || { echo "Check-out failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big || exit 1
+
+############################################################
+echo "*** A small file stays a single raw blob"
+
+(cd /tmp && true) # no-op to keep structure clear
+$BOAR --repo=$REPO co Big || exit 1
+(cd Big &&
+    head -c 1000 $BIGFILE >small.bin &&
+    SMALLMD5=`md5sum small.bin | cut -d' ' -f1` &&
+    md5sum bigfile.bin small.bin >manifest.md5 &&
+    $BOAR ci -q &&
+    test -e $REPO/blobs/${SMALLMD5:0:2}/$SMALLMD5 || { echo "Small file should be a raw blob"; exit 1; }
+    test ! -e $REPO/recipes/${SMALLMD5:0:2}/$SMALLMD5.recipe || { echo "Small file should not have a recipe"; exit 1; }
+) || exit 1
+assert_no_blob_over $REPO $MAX
+$BOAR --repo=$REPO verify || { echo "Verify failed"; exit 1; }
+rm -r Big || exit 1
+
+############################################################
+echo "*** Cloning a split repo into a plain repo reassembles the file"
+
+CLONE_PLAIN=$TESTDIR/clone_plain
+$BOAR clone $REPO $CLONE_PLAIN || { echo "Clone failed"; exit 1; }
+test ! -e $CLONE_PLAIN/maxblobsize.txt || { echo "Plain clone unexpectedly has a max blob size"; exit 1; }
+# Without a limit, the big file is stored as a single raw blob.
+test -e $CLONE_PLAIN/blobs/d9/$BIGMD5 || { echo "Expected reassembled raw blob in plain clone"; exit 1; }
+test ! -e $CLONE_PLAIN/recipes/d9/$BIGMD5.recipe || { echo "Plain clone should not have a recipe"; exit 1; }
+$BOAR --repo=$CLONE_PLAIN verify || { echo "Plain clone verify failed"; exit 1; }
+$BOAR --repo=$CLONE_PLAIN co Big || { echo "Plain clone checkout failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big || exit 1
+
+############################################################
+echo "*** Cloning into a repo with a (different) limit re-splits the file"
+
+CLONE_SPLIT=$TESTDIR/clone_split
+$BOAR mkrepo --max-file-size 70k $CLONE_SPLIT || exit 1
+$BOAR clone $REPO $CLONE_SPLIT || { echo "Clone (split) failed"; exit 1; }
+assert_no_blob_over $CLONE_SPLIT 71680
+test -e $CLONE_SPLIT/recipes/d9/$BIGMD5.recipe || { echo "Re-split clone is missing the recipe"; exit 1; }
+$BOAR --repo=$CLONE_SPLIT verify || { echo "Re-split clone verify failed"; exit 1; }
+$BOAR --repo=$CLONE_SPLIT co Big || { echo "Re-split clone checkout failed"; exit 1; }
+(cd Big && md5sum -c manifest.md5 ) || exit 1
+rm -r Big $CLONE_PLAIN $CLONE_SPLIT $REPO || exit 1
+
+############################################################
+if [ "$BOAR_SKIP_DEDUP_TESTS" == "1" ]; then
+    echo "Skipping deduplication part due to BOAR_SKIP_DEDUP_TESTS"
+    exit 0
+fi
+
+echo "*** Splitting combined with deduplication"
+
+$BOAR mkrepo --enable-deduplication --max-file-size 100k $REPO || exit 1
+$BOAR --repo=$REPO mksession Dedup || exit 1
+$BOAR --repo=$REPO co Dedup || exit 1
+(cd Dedup &&
+    cp $BIGFILE a.bin &&
+    $BOAR ci -q ) || exit 1
+raw_after_first=`find $REPO/blobs -type f | wc -l`
+
+(cd Dedup &&
+    ( echo "a unique short prefix"; cat $BIGFILE ) >b.bin &&
+    md5sum a.bin b.bin >manifest.md5 &&
+    $BOAR ci -q ) || exit 1
+raw_after_second=`find $REPO/blobs -type f | wc -l`
+
+assert_no_blob_over $REPO $MAX
+# Deduplication should keep the number of new raw blobs small, even
+# though the shared body is stored split across several sub-blobs.
+new_blobs=$((raw_after_second - raw_after_first))
+echo "New raw blobs from the near-identical second file: $new_blobs"
+if [ "$new_blobs" -gt 3 ]; then
+    echo "*** FAIL: deduplication across split boundaries did not work ($new_blobs new blobs)"
+    exit 1
+fi
+
+$BOAR --repo=$REPO verify || { echo "Dedup verify failed"; exit 1; }
+rm -r Dedup || exit 1
+$BOAR --repo=$REPO co Dedup || { echo "Dedup checkout failed"; exit 1; }
+(cd Dedup && md5sum -c manifest.md5 ) || exit 1
+rm -r Dedup $REPO || exit 1
+
+exit 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 setuptools>=65
 pytest
+# Optional: only required for repositories created with "--compress lz4".
+# The gzip/xz/bz2 algorithms use the Python standard library.
+lz4

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,359 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2010 Mats Ekberg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the blob compression feature: a repository may store all
+blob data compressed with a chosen algorithm, described by a "compress"
+recipe."""
+
+import sys, os, unittest, shutil, random
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import workdir
+import compression
+import deduplication
+from blobrepo import repository, blobreader
+from common import md5sum, DevNull
+from boar_exceptions import UserError, CorruptionError
+from front import Front, verify_repo
+from wdtools import WorkdirHelper
+
+AVAILABLE = [a for a in compression.KNOWN_ALGORITHMS if compression.is_available(a)]
+
+
+def deterministic_bytes(n, seed=0):
+    rnd = random.Random(seed)
+    return bytes(rnd.randrange(256) for _ in range(n))
+
+
+class TestCodecs(unittest.TestCase):
+    """The codec layer on its own: stream compress, then stream
+    decompress through the same pump loop CompressReader uses."""
+
+    DATASETS = {
+        "empty": b"",
+        "tiny": b"x",
+        "text": b"the quick brown fox\n" * 3000,
+        "zeros": b"\x00" * 200000,
+        "random": deterministic_bytes(150000, seed=99),
+        "blocksize": deterministic_bytes(65536, seed=7),
+    }
+
+    def _compress(self, algo, data, chunk=4096):
+        c = compression.get_codec(algo).compressor()
+        out = b"".join(c.compress(data[i:i + chunk]) for i in range(0, len(data), chunk))
+        return out + c.flush()
+
+    def _decompress(self, algo, comp, in_chunk=1024, out_chunk=1000):
+        d = compression.get_codec(algo).decompressor()
+        out = b""
+        pos = 0
+        while True:
+            if d.needs_input:
+                if pos >= len(comp):
+                    break
+                feed = comp[pos:pos + in_chunk]
+                pos += len(feed)
+            else:
+                feed = b""
+            out += d.decompress(feed, out_chunk)
+            if d.eof:
+                break
+        return out
+
+    def testRoundtrips(self):
+        for algo in AVAILABLE:
+            for name, data in self.DATASETS.items():
+                comp = self._compress(algo, data)
+                back = self._decompress(algo, comp)
+                self.assertEqual(back, data, "%s/%s roundtrip failed" % (algo, name))
+
+    def testUnknownAlgorithmRejected(self):
+        self.assertRaises(UserError, compression.get_codec, "nonsense")
+
+    def testAliases(self):
+        self.assertEqual(compression.canonical_name("gz"), "gzip")
+        self.assertEqual(compression.canonical_name("LZMA"), "xz")
+        self.assertEqual(compression.canonical_name("bzip2"), "bz2")
+
+
+class TestCompressReader(unittest.TestCase, WorkdirHelper):
+    def setUp(self):
+        self.remove_at_teardown = []
+        self.tmp = self.createTmpName()
+        os.mkdir(self.tmp)
+
+    def tearDown(self):
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    class _FakeRepo(object):
+        def __init__(self, blobdir):
+            self.blobdir = blobdir
+
+        def get_blob_path(self, blob):
+            return os.path.join(self.blobdir, blob)
+
+    def _make_recipe(self, algo, data, split=None):
+        c = compression.get_codec(algo).compressor()
+        comp = b"".join(c.compress(data[i:i + 4096]) for i in range(0, len(data), 4096)) + c.flush()
+        if split is None:
+            split = max(len(comp), 1)
+        pieces = []
+        for i in range(0, max(len(comp), 1), split):
+            chunk = comp[i:i + split]
+            if not chunk and i > 0:
+                break
+            name = md5sum(chunk)
+            with open(os.path.join(self.tmp, name), "wb") as f:
+                f.write(chunk)
+            pieces.append({"source": name, "offset": 0, "size": len(chunk)})
+        return {"method": "compress", "algorithm": algo, "md5sum": md5sum(data),
+                "size": len(data), "pieces": pieces}
+
+    def testFullAndRandomAccess(self):
+        repo = self._FakeRepo(self.tmp)
+        for algo in AVAILABLE:
+            data = deterministic_bytes(120000, seed=3) + b"tail"
+            for split in (None, 4096):
+                recipe = self._make_recipe(algo, data, split)
+                # full streaming read
+                r = blobreader.CompressReader(recipe, repo)
+                full = b""
+                while r.bytes_left():
+                    full += r.read(777)
+                self.assertEqual(full, data, "%s split=%s full read" % (algo, split))
+                # random access
+                for off, size in [(0, 5), (len(data) // 2, 100), (len(data) - 3, 3), (10, len(data) - 10)]:
+                    rr = blobreader.CompressReader(recipe, repo, offset=off, size=size)
+                    got = b""
+                    while rr.bytes_left():
+                        got += rr.read(64)
+                    self.assertEqual(got, data[off:off + size], "%s split=%s [%s:%s]" % (algo, split, off, off + size))
+
+
+class TestRepoConfig(unittest.TestCase, WorkdirHelper):
+    def setUp(self):
+        self.remove_at_teardown = []
+
+    def tearDown(self):
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def testDefaultIsNone(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath)
+        self.assertEqual(repository.Repo(repopath).get_compression(), None)
+
+    def testStoredCanonical(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath, compression_algorithm="gz")  # alias
+        self.assertEqual(repository.Repo(repopath).get_compression(), "gzip")
+        stats = dict(repository.Repo(repopath).get_stats())
+        self.assertEqual(stats["compression"], "gzip")
+
+    def testUnknownAlgorithmRejected(self):
+        repopath = self.createTmpName()
+        self.assertRaises(UserError, repository.create_repository,
+                          repopath, compression_algorithm="nope")
+        self.assertFalse(os.path.exists(repopath))
+
+
+class _CompressionWorkdirBase(unittest.TestCase, WorkdirHelper):
+    algorithm = "gzip"
+    max_blob_size = None
+    enable_deduplication = False
+
+    def setUp(self):
+        self.remove_at_teardown = []
+        self.workdir = self.createTmpName()
+        self.repopath = self.createTmpName()
+        repository.create_repository(self.repopath,
+                                     enable_deduplication=self.enable_deduplication,
+                                     max_blob_size=self.max_blob_size,
+                                     compression_algorithm=self.algorithm)
+        os.mkdir(self.workdir)
+        self.wd = workdir.Workdir(self.repopath, u"TestSession", u"", None, self.workdir)
+        self.wd.setLogOutput(DevNull())
+        self.wd.use_progress_printer(False)
+        self.repo = self.wd.front.repo
+        self.wd.get_front().mksession(u"TestSession")
+
+    def tearDown(self):
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def assert_roundtrip(self, md5, expected):
+        data = self.wd.front.get_blob(md5).read()
+        self.assertEqual(md5sum(data), md5)
+        self.assertEqual(data, expected)
+
+
+def _make_algorithm_case(algo):
+    class _Case(_CompressionWorkdirBase):
+        algorithm = algo
+
+        def testCompressedCommitRoundtrips(self):
+            text = b"highly compressible payload " * 8000
+            rnd = deterministic_bytes(120000, seed=5)
+            md5_text = self.addWorkdirFile("text.bin", text)
+            md5_rnd = self.addWorkdirFile("rand.bin", rnd)
+            md5_empty = self.addWorkdirFile("empty.bin", b"")
+            self.wd.checkin()
+
+            for md5 in (md5_text, md5_rnd, md5_empty):
+                self.assertTrue(self.repo.has_recipe_blob(md5))
+                self.assertFalse(self.repo.has_raw_blob(md5))
+                recipe = self.repo.get_recipe(md5)
+                self.assertEqual(recipe["method"], "compress")
+                self.assertEqual(recipe["algorithm"], algo)
+
+            # The compressible file must actually be stored smaller.
+            recipe = self.repo.get_recipe(md5_text)
+            stored = sum(os.path.getsize(self.repo.get_blob_path(p["source"])) for p in recipe["pieces"])
+            self.assertTrue(stored < len(text))
+
+            self.assert_roundtrip(md5_text, text)
+            self.assert_roundtrip(md5_rnd, rnd)
+            self.assert_roundtrip(md5_empty, b"")
+            self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+    _Case.__name__ = "TestCompress_" + algo
+    _Case.__qualname__ = _Case.__name__
+    return _Case
+
+
+# Generate one test class per available algorithm.
+_thismodule = sys.modules[__name__]
+for _algo in AVAILABLE:
+    setattr(_thismodule, "TestCompress_" + _algo, _make_algorithm_case(_algo))
+
+
+class TestCompressionWithMaxBlobSize(_CompressionWorkdirBase):
+    algorithm = "gzip"
+    max_blob_size = 65536
+
+    def testCompressedStreamIsSplit(self):
+        # Incompressible data => compressed size ~ original => must split.
+        data = deterministic_bytes(300000, seed=8)
+        md5 = self.addWorkdirFile("big.bin", data)
+        self.wd.checkin()
+        self.assertTrue(self.repo.has_recipe_blob(md5))
+        recipe = self.repo.get_recipe(md5)
+        self.assertTrue(len(recipe["pieces"]) > 1, "expected the compressed stream to be split")
+        for name in self.repo.get_raw_blob_names():
+            self.assertTrue(os.path.getsize(self.repo.get_blob_path(name)) <= self.max_blob_size)
+        self.assert_roundtrip(md5, data)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+class TestTruncationRaises(unittest.TestCase, WorkdirHelper):
+    """A sub-blob that is shorter on disk than its recipe claims must raise
+    CorruptionError, not spin forever (regression for the streaming reader)."""
+
+    def setUp(self):
+        self.remove_at_teardown = []
+        self.tmp = self.createTmpName()
+        os.mkdir(self.tmp)
+
+    def tearDown(self):
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    class _FakeRepo(object):
+        def __init__(self, blobdir):
+            self.blobdir = blobdir
+
+        def get_blob_path(self, blob):
+            return os.path.join(self.blobdir, blob)
+
+    def _write(self, data):
+        name = md5sum(data)
+        with open(os.path.join(self.tmp, name), "wb") as f:
+            f.write(data)
+        return name
+
+    def testConcatRecipeTruncatedSubBlob(self):
+        # A plain concat recipe (as produced by --max-file-size) with a
+        # source blob that is shorter than the recipe declares.
+        name = self._write(b"only-ten!!")  # 10 bytes on disk
+        recipe = {"method": "concat", "md5sum": "0" * 32, "size": 20,
+                  "pieces": [{"source": name, "offset": 0, "size": 20, "repeat": 1}]}
+        reader = blobreader.RecipeReader(recipe, self._FakeRepo(self.tmp))
+        self.assertRaises(CorruptionError, reader.read)
+
+    def testCompressTruncatedSubBlob(self):
+        algo = "gzip"
+        data = b"some compressible data " * 1000
+        c = compression.get_codec(algo).compressor()
+        comp = c.compress(data) + c.flush()
+        name = self._write(comp[:len(comp) // 2])  # truncate the compressed blob on disk
+        recipe = {"method": "compress", "algorithm": algo, "md5sum": md5sum(data),
+                  "size": len(data),
+                  "pieces": [{"source": name, "offset": 0, "size": len(comp)}]}
+        reader = blobreader.CompressReader(recipe, self._FakeRepo(self.tmp))
+        # Either a decompressor error or our truncation guard - but it must
+        # raise quickly, not hang.
+        self.assertRaises(Exception, lambda: b"".join(iter(lambda: reader.read(4096) or None, None)))
+
+
+class TestSubBlobNameCollision(_CompressionWorkdirBase):
+    """A file whose content equals boar's compressed representation of
+    another file shares an md5 between a raw sub-blob and a recipe. The
+    commit must reconcile this instead of aborting."""
+    algorithm = "gzip"
+
+    def testCollidingCommitSucceeds(self):
+        payload = b"highly compressible payload " * 50
+        c = compression.get_codec(self.algorithm).compressor()
+        compressed = c.compress(payload) + c.flush()
+        self.assertNotEqual(md5sum(compressed), md5sum(payload))
+        # "a_..." sorts before "z_...", so the file whose content is the
+        # compressed form is uploaded first (writes a recipe named
+        # md5(compressed)); the payload file is uploaded second (writes a
+        # raw sub-blob of the same name).
+        md5_compressed_file = self.addWorkdirFile("a_compressed.bin", compressed)
+        md5_payload_file = self.addWorkdirFile("z_payload.bin", payload)
+        self.assertEqual(md5_compressed_file, md5sum(compressed))
+        self.wd.checkin()  # must not raise
+        self.assert_roundtrip(md5_compressed_file, compressed)
+        self.assert_roundtrip(md5_payload_file, payload)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+@unittest.skipUnless(deduplication.dedup_available, "deduplication module not installed")
+class TestCompressionWinsOverDedup(_CompressionWorkdirBase):
+    algorithm = "gzip"
+    enable_deduplication = True
+
+    def testCompressionTakesPrecedence(self):
+        data = b"repeated block of bytes " * 5000
+        md5 = self.addWorkdirFile("a.bin", data)
+        self.wd.checkin()
+        recipe = self.repo.get_recipe(md5)
+        self.assertEqual(recipe["method"], "compress")
+        self.assert_roundtrip(md5, data)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+if __name__ == '__main__':
+    print("Available compression algorithms:", AVAILABLE)
+    unittest.main()

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -48,6 +48,7 @@ class FakePieceHandler(object):
     def end_piece(self, index): pass
     def close(self): pass
     def get_piece_address(self, index): return ("FAKEBLOB", 0)
+    def get_piece_segments(self, index, size): return [("FAKEBLOB", 0, size)]
 
 
 class TestRecipeFinder(unittest.TestCase, WorkdirHelper):

--- a/tests/test_maxblobsize.py
+++ b/tests/test_maxblobsize.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2010 Mats Ekberg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the per-repository maximum blob size feature, which
+splits oversized files into several smaller blobs tied together with a
+recipe."""
+
+import sys, os, unittest
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import workdir
+from blobrepo import repository
+from common import md5sum, DevNull, parse_human_size
+from boar_exceptions import UserError
+from front import Front, verify_repo
+from deduplication import dedup_available
+from wdtools import WorkdirHelper
+
+
+def deterministic_bytes(n, seed=0):
+    """Return n bytes of deterministic, hard-to-compress data."""
+    return bytes(((i * 2654435761 + seed * 40503 + 7) % 251) for i in range(n))
+
+
+class TestParseHumanSize(unittest.TestCase):
+    def testPlainInteger(self):
+        self.assertEqual(parse_human_size("0"), 0)
+        self.assertEqual(parse_human_size("65536"), 65536)
+        self.assertEqual(parse_human_size(" 100 "), 100)
+
+    def testSuffixes(self):
+        self.assertEqual(parse_human_size("1k"), 1024)
+        self.assertEqual(parse_human_size("1K"), 1024)
+        self.assertEqual(parse_human_size("2M"), 2 * 1024 ** 2)
+        self.assertEqual(parse_human_size("3g"), 3 * 1024 ** 3)
+        self.assertEqual(parse_human_size("1T"), 1024 ** 4)
+
+    def testByteMarker(self):
+        self.assertEqual(parse_human_size("100b"), 100)
+        self.assertEqual(parse_human_size("5MB"), 5 * 1024 ** 2)
+        self.assertEqual(parse_human_size("5mb"), 5 * 1024 ** 2)
+
+    def testFractional(self):
+        self.assertEqual(parse_human_size("1.5k"), 1536)
+
+    def testMalformed(self):
+        for bad in ("", "   ", "abc", "1.2.3", "k", "M", "-5", "-1k", "5x",
+                    "inf", "infinity", "infg", "nan", "9" * 400):
+            self.assertRaises(ValueError, parse_human_size, bad)
+
+
+class TestRepoConfig(unittest.TestCase, WorkdirHelper):
+    def setUp(self):
+        self.remove_at_teardown = []
+
+    def tearDown(self):
+        import shutil
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def testDefaultIsNone(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath)
+        repo = repository.Repo(repopath)
+        self.assertEqual(repo.get_max_blob_size(), None)
+
+    def testStoredAndRead(self):
+        repopath = self.createTmpName()
+        repository.create_repository(repopath, max_blob_size=131072)
+        self.assertTrue(os.path.exists(os.path.join(repopath, repository.MAXBLOBSIZE_FILE)))
+        repo = repository.Repo(repopath)
+        self.assertEqual(repo.get_max_blob_size(), 131072)
+        # Make sure it is reported in the repo statistics too.
+        stats = dict(repo.get_stats())
+        self.assertEqual(stats["max_blob_size"], 131072)
+
+    def testBelowMinimumRejected(self):
+        repopath = self.createTmpName()
+        self.assertRaises(UserError, repository.create_repository,
+                          repopath, max_blob_size=repository.MIN_MAX_BLOB_SIZE - 1)
+        self.assertFalse(os.path.exists(repopath))
+
+    def testCorruptConfigRaisesCorruptionError(self):
+        from boar_exceptions import CorruptionError
+        repopath = self.createTmpName()
+        repository.create_repository(repopath, max_blob_size=131072)
+        with open(os.path.join(repopath, repository.MAXBLOBSIZE_FILE), "wb") as f:
+            f.write(b"not-a-number")
+        repo = repository.Repo(repopath)
+        self.assertRaises(CorruptionError, repo.get_max_blob_size)
+
+
+class _SplitTestBase(unittest.TestCase, WorkdirHelper):
+    enable_deduplication = False
+
+    def setUp(self):
+        self.remove_at_teardown = []
+        self.workdir = self.createTmpName()
+        self.repopath = self.createTmpName()
+        self.max_blob_size = 65536
+        repository.create_repository(self.repopath,
+                                     enable_deduplication=self.enable_deduplication,
+                                     max_blob_size=self.max_blob_size)
+        os.mkdir(self.workdir)
+        self.wd = workdir.Workdir(self.repopath, u"TestSession", u"", None, self.workdir)
+        self.wd.setLogOutput(DevNull())
+        self.wd.use_progress_printer(False)
+        self.repo = self.wd.front.repo
+        self.wd.get_front().mksession(u"TestSession")
+
+    def tearDown(self):
+        import shutil
+        for path in self.remove_at_teardown:
+            if os.path.exists(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def assert_blob_size_invariant(self):
+        """No raw blob in the repository may exceed the configured limit."""
+        for name in self.repo.get_raw_blob_names():
+            size = os.path.getsize(self.repo.get_blob_path(name))
+            self.assertTrue(size <= self.max_blob_size,
+                            "Raw blob %s has size %s > limit %s" % (name, size, self.max_blob_size))
+
+    def assert_roundtrip(self, md5, expected_content):
+        reader = self.wd.front.get_blob(md5)
+        data = reader.read()
+        self.assertEqual(len(data), len(expected_content))
+        self.assertEqual(md5sum(data), md5)
+        self.assertEqual(data, expected_content)
+
+
+class TestSplitNoDedup(_SplitTestBase):
+    enable_deduplication = False
+
+    def testFileLargerThanLimitGetsRecipe(self):
+        content = deterministic_bytes(350000, seed=1)  # not a multiple of the limit
+        md5 = self.addWorkdirFile("big.bin", content)
+        self.wd.checkin()
+        # The file must be represented by a recipe, not a single raw blob.
+        self.assertTrue(self.repo.has_recipe_blob(md5))
+        self.assertFalse(self.repo.has_raw_blob(md5))
+        recipe = self.repo.get_recipe(md5)
+        self.assertEqual(recipe["size"], len(content))
+        self.assertEqual(sum(p["size"] * p["repeat"] for p in recipe["pieces"]), len(content))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5, content)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+    def testFileAtAndBelowLimitStaysRaw(self):
+        exact = deterministic_bytes(self.max_blob_size, seed=2)
+        small = deterministic_bytes(1000, seed=3)
+        md5_exact = self.addWorkdirFile("exact.bin", exact)
+        md5_small = self.addWorkdirFile("small.bin", small)
+        self.wd.checkin()
+        for md5 in (md5_exact, md5_small):
+            self.assertTrue(self.repo.has_raw_blob(md5))
+            self.assertFalse(self.repo.has_recipe_blob(md5))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5_exact, exact)
+        self.assert_roundtrip(md5_small, small)
+
+    def testEmptyFile(self):
+        md5 = self.addWorkdirFile("empty.bin", b"")
+        self.wd.checkin()
+        self.assertEqual(md5, "d41d8cd98f00b204e9800998ecf8427e")
+        self.assertTrue(self.repo.has_raw_blob(md5))
+        self.assertFalse(self.repo.has_recipe_blob(md5))
+        self.assert_roundtrip(md5, b"")
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+    def testIdenticalLargeFilesShareSubBlobs(self):
+        content = deterministic_bytes(200000, seed=4)
+        self.addWorkdirFile("a.bin", content)
+        self.addWorkdirFile("b.bin", content)
+        self.wd.checkin()
+        # Two identical files share the same recipe and the same set of
+        # sub-blobs, so the raw blob count is exactly the number of
+        # chunks of a single file.
+        expected_chunks = (len(content) + self.max_blob_size - 1) // self.max_blob_size
+        self.assertEqual(len(self.repo.get_raw_blob_names()), expected_chunks)
+        self.assertEqual(len(self.repo.get_recipe_names()), 1)
+        self.assert_blob_size_invariant()
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+@unittest.skipUnless(dedup_available, "deduplication module not installed")
+class TestSplitWithDedup(_SplitTestBase):
+    enable_deduplication = True
+
+    def testDedupAcrossSplitBoundaries(self):
+        base = deterministic_bytes(300000, seed=5)
+        md5_a = self.addWorkdirFile("a.bin", base)
+        self.wd.checkin()
+        raw_after_first = len(self.repo.get_raw_blob_names())
+
+        # A second file that contains the same large body with a small
+        # prefix. Block deduplication should recognise the shared body
+        # even though it is stored split across several sub-blobs, so
+        # only a small amount of new raw data is added.
+        b_content = b"A short unique prefix.\n" + base
+        md5_b = self.addWorkdirFile("b.bin", b_content)
+        self.wd.checkin()
+        raw_after_second = len(self.repo.get_raw_blob_names())
+
+        self.assertTrue(self.repo.has_recipe_blob(md5_b))
+        recipe_b = self.repo.get_recipe(md5_b)
+        self.assertTrue(any(not p["original"] for p in recipe_b["pieces"]),
+                        "Expected deduplicated (non-original) pieces in the recipe")
+        # Far fewer new blobs than a naive re-split would require.
+        self.assertTrue(raw_after_second - raw_after_first <= 2,
+                        "Too many new raw blobs: %s -> %s" % (raw_after_first, raw_after_second))
+        self.assert_blob_size_invariant()
+        self.assert_roundtrip(md5_a, base)
+        self.assert_roundtrip(md5_b, b_content)
+        self.assertTrue(verify_repo(self.wd.front, verbose=False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
> Stacked on #138 — review/merge that first; this PR's base will auto-retarget to `main` once it merges.

"boar mkrepo --compress ALGORITHM" (gzip, xz, bz2 or lz4) stores every
committed blob's data compressed, as one or more raw sub-blobs tied together
with a new self-describing "compress" recipe named by the uncompressed md5.

Boar stays algorithm-agnostic: reading only needs the matching codec, and a
repo whose codec is unavailable opens read-only. Compression is a write-side
property (clone re-compresses), composes with `--max-file-size` (the
compressed stream is split), and takes precedence over deduplication.

Also hardens the shared recipe reader: a sub-blob shorter on disk than its
recipe claims now raises `CorruptionError` instead of looping forever, and a
raw-blob/recipe md5 name collision is reconciled (the raw blob wins) instead
of aborting the commit.

Tested by `tests/test_compression.py` and `macrotests/test_compression.sh`
(local and simulated-remote modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
