### PR TITLE
clone: contiguous blob numbering + report already-present blobs

### DIFF
--- a/boar
+++ b/boar
@@ -1408,7 +1408,11 @@ def __clone_once(source_front, target_front, skip_verify=False, reflink=False):
 
     stats = front.clone(source_front, target_front, reflink = reflink)
     if reflink:
-        print("Reflinked %d blob(s); copied %d blob(s)." % (stats["reflinked"], stats["copied"]))
+        print("Reflinked %d blob(s); copied %d blob(s); %d blob(s) already present." %
+              (stats["reflinked"], stats["copied"], stats["present"]))
+    else:
+        print("Copied %d blob(s); %d blob(s) already present." %
+              (stats["copied"], stats["present"]))
 
     if not skip_verify:
         print("Performing full verify on cloned repo")

--- a/front.py
+++ b/front.py
@@ -79,8 +79,9 @@ valid_session_props = set(["ignore", "include"])
 
 def clone(from_front, to_front, reflink = False):
     """Clone all new snapshots from from_front into to_front. Returns a
-    statistics dict with the number of blobs 'reflinked' and 'copied'."""
-    stats = {"reflinked": 0, "copied": 0}
+    statistics dict with the number of blobs 'reflinked', 'copied' and
+    'present' (already in the destination, so skipped)."""
+    stats = {"reflinked": 0, "copied": 0, "present": 0}
     from_front.acquire_repo_lock()
     to_front.acquire_repo_lock()
     try:
@@ -191,11 +192,35 @@ def __clone_single_snapshot(from_front, to_front, session_id, reflink = False, s
     assert from_front != to_front
     other_bloblist = from_front.get_session_bloblist(session_id)
     other_raw_bloblist = from_front.get_session_raw_bloblist(session_id)
-    for n, blobinfo in enumerate(other_raw_bloblist):
+
+    # Work out up front how many blobs actually need transferring, so the
+    # progress can be numbered contiguously ("blob 3 of 40"). Numbering by
+    # each blob's position in the full list instead makes the visible
+    # sequence jump (e.g. 9, 11, 13...) wherever a blob the destination
+    # already has was silently skipped, which looks like something is wrong.
+    seen = set()
+    blobs_to_transfer = 0
+    for blobinfo in other_raw_bloblist:
+        if blobinfo.get("action", None):
+            continue
+        md5sum = blobinfo['md5sum']
+        if md5sum in seen or to_front.has_blob(md5sum):
+            continue
+        seen.add(md5sum)
+        blobs_to_transfer += 1
+
+    transferred = 0
+    for blobinfo in other_raw_bloblist:
         action = blobinfo.get("action", None)
         if not action:
             md5sum = blobinfo['md5sum']
-            if not (to_front.has_blob(md5sum) or to_front.new_snapshot_has_blob(md5sum)):
+            if to_front.has_blob(md5sum) or to_front.new_snapshot_has_blob(md5sum):
+                # The destination already has this blob (from an earlier
+                # snapshot or earlier in this one); nothing to send.
+                if stats is not None:
+                    stats["present"] += 1
+            else:
+                transferred += 1
                 reflinked = False
                 if reflink and _local_source_has_raw_blob(from_front, to_front, md5sum):
                     # Offer the destination the source's raw blob file to share
@@ -216,7 +241,7 @@ def __clone_single_snapshot(from_front, to_front, session_id, reflink = False, s
                 if not reflinked:
                     pp = SimpleProgressPrinter(sys.stdout,
                                                label="Sending blob %s of %s (%s MB)" %
-                                               (n+1, len(other_raw_bloblist),
+                                               (transferred, blobs_to_transfer,
                                                 round((blobinfo['size'] / float(2**20)), 3)))
                     sw = StopWatch(enabled=False, name="front.clone")
                     to_front.init_new_blob(md5sum, blobinfo['size'])

--- a/tests/test_reflink.py
+++ b/tests/test_reflink.py
@@ -230,7 +230,7 @@ class TestReflinkClone(unittest.TestCase):
 
         # Both blobs were reflinked (a successful FICLONE means the data is
         # shared copy-on-write); none were copied.
-        self.assertEqual(self.last_stats, {"reflinked": 2, "copied": 0})
+        self.assertEqual(self.last_stats, {"reflinked": 2, "copied": 0, "present": 0})
         # All blobs present as raw blobs, content correct, repo verifies.
         for name, data in payload.items():
             md5 = md5sum(data)
@@ -299,7 +299,7 @@ class TestReflinkClone(unittest.TestCase):
 
         # The two unique blobs (a.bin, c.bin) are stored verbatim and shared
         # via reflink; the duplicate (b.bin) is deduplicated, not reflinked.
-        self.assertEqual(self.last_stats, {"reflinked": 2, "copied": 1})
+        self.assertEqual(self.last_stats, {"reflinked": 2, "copied": 1, "present": 0})
         self.assertTrue(target.repo.has_raw_blob(md5sum(base)))
         self.assertTrue(target.repo.has_raw_blob(md5sum(uniq)))
         self.assertEqual(target.get_blob(md5sum(uniq)).read(), uniq)


### PR DESCRIPTION
## Problem

During `boar clone`, the per-blob progress line is numbered by each blob's absolute index in the full bloblist (`Sending blob N of M`), but the line is only printed when the blob actually needs sending. Blobs the destination already has are silently skipped, so the visible numbers jump:

```
Sending blob 8 of 592 ...
Sending blob 9 of 592 ...
Sending blob 11 of 592 ...   <- 10 skipped silently
Sending blob 13 of 592 ...   <- 12 skipped silently
```

This looks like something has gone wrong, and the skipped blobs were never reported anywhere.

A blob counts as "already present" when `has_blob()` is true (committed earlier, including from an earlier snapshot in the same clone) or `new_snapshot_has_blob()` is true (a duplicate of content already sent earlier within the same snapshot — the common cause in a large initial import where many files share content).

## Fix

- Pre-scan the bloblist to count how many blobs genuinely need transferring, and number sent blobs against that count so the sequence is contiguous (`blob 1 of 4 … 4 of 4`). The pre-scan mirrors the live skip logic exactly (same `has_blob` check plus a `seen` set standing in for `new_snapshot_has_blob`).
- Track already-present blobs in the clone stats (`present`) and always print a summary so the skips are no longer silent:
  - `Copied N blob(s); M blob(s) already present.`
  - `Reflinked X blob(s); copied N blob(s); M blob(s) already present.` under `--reflink`

## Verification

- Reproduced the jumping-numbers scenario (10 files, only 4 unique blobs) via both the `front.clone()` API and the real `boar clone` CLI — numbering is now contiguous and reports `6 blob(s) already present`.
- `tests/test_reflink.py`: 13/13 pass (updated the two `last_stats` assertions for the new `present` key).
- Full macrotest suite (all 30 tests, incl. `test_clone.sh`, `test_reflink.sh`, `test_truncate_clone.sh`): `All macrotests completed ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)